### PR TITLE
chore: vite.config mock after mocks 오타 수정

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "incremental": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,
@@ -10,7 +11,6 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
@@ -20,7 +20,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
 
     "baseUrl": ".",
     "paths": {

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "incremental": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "ES2022",
     "lib": ["ES2023"],
@@ -18,7 +19,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "verbatimModuleSyntax": true
   },
   "include": ["vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     alias: {
       "@shadcn": path.resolve(__dirname, "./src/shadcn"),
       "@assets": path.resolve(__dirname, "./src/assets"),
-      "@mocks": path.resolve(__dirname, "./src/mock"),
+      "@mocks": path.resolve(__dirname, "./src/mocks"),
     },
   },
   define: {


### PR DESCRIPTION
tsconfig 오류 수정
- tsBuildInfoFile 옵션은 incremental 옵션을 추가해야 합니다.
- noUncheckedSideEffectImports는 TypeScript 5.0 이전에는 실험적 기능이었고, 현재는 더 이상 지원되지 않는 옵션입니다.