### PR TITLE
feat: 모바일 하단 네비게이션 및 라우트 설정 추가 🚀

### DIFF
--- a/src/app/layouts/app-layout.tsx
+++ b/src/app/layouts/app-layout.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from 'react-router-dom';
+import { BottomNavigation } from '@widgets/navigation';
+
+export const AppLayout = () => {
+  return (
+    <div className="min-h-screen">
+      <main className="container">
+        <Outlet />
+      </main>
+      <BottomNavigation />
+    </div>
+  );
+}; 

--- a/src/app/layouts/basic-layout.tsx
+++ b/src/app/layouts/basic-layout.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from 'react-router-dom';
+
+export const BasicLayout = () => {
+  return (
+    <div className="min-h-screen">
+      <main className="container mx-auto px-4 py-8">
+        <Outlet />
+      </main>
+    </div>
+  );
+}; 

--- a/src/app/providers/with-suspense.tsx
+++ b/src/app/providers/with-suspense.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from 'react';
+import type { ComponentType } from 'react';
+import { LoadingSpinner } from '@shared/ui';
+
+interface WithSuspenseOptions {
+  fallback?: React.ReactNode;
+}
+
+export const withSuspense = (
+  Component: React.LazyExoticComponent<ComponentType<any>>,
+  options: WithSuspenseOptions = {}
+) => {
+  return function SuspenseWrapper() {
+    return (
+      <Suspense fallback={options.fallback ?? <LoadingSpinner />}>
+        <Component />
+      </Suspense>
+    );
+  };
+}; 

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,9 +1,50 @@
 import { createBrowserRouter } from 'react-router-dom';
+import { lazy } from 'react';
 import App from '../App';
-export const router = createBrowserRouter([
-  {
-    path: '/',
-    element: <App />,
-    children: [],
-  },
-]);
+import { BasicLayout } from './layouts/basic-layout';
+import { AppLayout } from './layouts/app-layout';
+import { withSuspense } from './providers/with-suspense';
+import { ROUTES } from '@shared/config/routes';
+import { SplashPage } from '@pages/basic/splash';
+
+// Lazy load pages
+const LoginPage = lazy(() => import('@pages/basic/login').then(m => ({ default: m.LoginPage })));
+const HomePage = lazy(() => import('@pages/app/home').then(m => ({ default: m.HomePage })));
+const PaymentsPage = lazy(() => import('@pages/app/payments').then(m => ({ default: m.PaymentsPage })));
+const ScanPage = lazy(() => import('@pages/app/scan').then(m => ({ default: m.ScanPage })));
+const ProfilePage = lazy(() => import('@pages/app/profile').then(m => ({ default: m.ProfilePage })));
+
+// withSuspense로 감싸기
+const SuspendedLoginPage = withSuspense(LoginPage);
+const SuspendedHomePage = withSuspense(HomePage);
+const SuspendedPaymentsPage = withSuspense(PaymentsPage);
+const SuspendedScanPage = withSuspense(ScanPage);
+const SuspendedProfilePage = withSuspense(ProfilePage);
+
+// 라우트 설정
+const routes = {
+  path: '/',
+  element: <App />,
+  children: [
+    {
+      path: '/basic',
+      element: <BasicLayout />,
+      children: [
+        { path: ROUTES.BASIC.SPLASH, element: <SplashPage /> },
+        { path: ROUTES.BASIC.LOGIN, element: <SuspendedLoginPage /> },
+      ]
+    },
+    {
+      path: '/app',
+      element: <AppLayout />,
+      children: [
+        { path: ROUTES.APP.HOME, element: <SuspendedHomePage /> },
+        { path: ROUTES.APP.PAYMENTS, element: <SuspendedPaymentsPage /> },
+        { path: ROUTES.APP.SCAN, element: <SuspendedScanPage /> },
+        { path: ROUTES.APP.PROFILE, element: <SuspendedProfilePage /> }
+      ]
+    }
+  ]
+};
+
+export const router = createBrowserRouter([routes]);

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* 모바일 뷰포트 높이 대응 */
+@supports (-webkit-touch-callout: none) {
+    .min-h-screen {
+      min-height: -webkit-fill-available;
+    }
+  }
+  
+  /* 모바일 홈바 안전 영역 대응 */
+  .safe-area-bottom {
+    padding-bottom: env(safe-area-inset-bottom);
+  }

--- a/src/pages/app/home.tsx
+++ b/src/pages/app/home.tsx
@@ -1,0 +1,5 @@
+export const HomePage = () => {
+  return <h1>Home Page</h1>;
+};
+
+export default HomePage;

--- a/src/pages/app/payments.tsx
+++ b/src/pages/app/payments.tsx
@@ -1,0 +1,5 @@
+export const PaymentsPage = () => {
+  return <h1>Payments Page</h1>;
+};
+
+export default PaymentsPage;

--- a/src/pages/app/profile.tsx
+++ b/src/pages/app/profile.tsx
@@ -1,0 +1,5 @@
+export const ProfilePage = () => {
+  return <h1>Profile Page</h1>;
+};
+
+export default ProfilePage;

--- a/src/pages/app/scan.tsx
+++ b/src/pages/app/scan.tsx
@@ -1,0 +1,5 @@
+export const ScanPage = () => {
+  return <h1>Scan Page</h1>;
+};
+
+export default ScanPage;

--- a/src/pages/basic/login.tsx
+++ b/src/pages/basic/login.tsx
@@ -1,0 +1,3 @@
+export const LoginPage = () => {
+    return <h1 className="text-2xl">Login Page</h1>;
+  };

--- a/src/pages/basic/splash.tsx
+++ b/src/pages/basic/splash.tsx
@@ -1,0 +1,5 @@
+export const SplashPage = () => {
+  return <h1>Splash Page</h1>;
+};
+
+export default SplashPage;

--- a/src/shared/config/routes.ts
+++ b/src/shared/config/routes.ts
@@ -1,0 +1,15 @@
+export const ROUTES = {
+  BASIC: {
+    LOGIN: '/basic/login',
+    SPLASH: '/basic/splash'
+  },
+  APP: {
+    HOME: '/app/home',
+    SCAN: '/app/scan',
+    PAYMENTS: '/app/payments',
+    PROFILE: '/app/profile'
+  }
+} as const;
+
+export type BasicRoutes = keyof typeof ROUTES.BASIC;
+export type AppRoutes = keyof typeof ROUTES.APP; 

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,0 +1,1 @@
+export { LoadingSpinner } from './loading-spinner';

--- a/src/shared/ui/loading-spinner.tsx
+++ b/src/shared/ui/loading-spinner.tsx
@@ -1,0 +1,26 @@
+import { cn } from 'src/lib/shadcn/lib/utils';
+
+interface LoadingSpinnerProps {
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+export const LoadingSpinner = ({ size = 'md', className }: LoadingSpinnerProps) => {
+  const sizeClasses = {
+    sm: 'w-4 h-4',
+    md: 'w-8 h-8',
+    lg: 'w-12 h-12'
+  };
+
+  return (
+    <div className="flex items-center justify-center w-full h-full min-h-[100px]">
+      <div
+        className={cn(
+          'animate-spin rounded-full border-2 border-primary border-t-transparent',
+          sizeClasses[size],
+          className
+        )}
+      />
+    </div>
+  );
+}; 

--- a/src/widgets/navigation/index.ts
+++ b/src/widgets/navigation/index.ts
@@ -1,0 +1,6 @@
+export { BottomNavigation } from './ui/bottom-nav';
+export { NAVIGATION_ITEMS } from './model/constants';
+export type { 
+  NavItem, 
+  NavItemProps 
+} from './model/types';

--- a/src/widgets/navigation/model/constants.ts
+++ b/src/widgets/navigation/model/constants.ts
@@ -1,0 +1,30 @@
+import { House, CircleDollarSign, CreditCard, CircleUserRound } from 'lucide-react';
+import type { NavItem } from './types';
+import { ROUTES } from '@shared/config/routes';
+
+export const NAVIGATION_ITEMS: NavItem[] = [
+  {
+    id: 'home',
+    label: '홈',
+    icon: House,
+    path: ROUTES.APP.HOME,
+  },
+  {
+    id: 'scan',
+    label: 'QR스캔',
+    icon: CircleDollarSign,
+    path: ROUTES.APP.SCAN,
+  },
+  {
+    id: 'payments',
+    label: '결제내역',
+    icon: CreditCard,
+    path: ROUTES.APP.PAYMENTS,
+  },
+  {
+    id: 'profile',
+    label: '내정보',
+    icon: CircleUserRound,
+    path: ROUTES.APP.PROFILE,
+  },
+] as const;

--- a/src/widgets/navigation/model/types.ts
+++ b/src/widgets/navigation/model/types.ts
@@ -1,0 +1,18 @@
+import { ROUTES } from '@shared/config/routes';
+import type { FC } from 'react';
+import type { LucideProps } from 'lucide-react';
+
+export type NavigationID = 'home' | 'scan' | 'payments' | 'profile';
+export type NavigationPath = typeof ROUTES.APP[keyof typeof ROUTES.APP];
+
+export interface NavItem {
+  id: NavigationID;
+  label: string;
+  icon: FC<LucideProps>;
+  path: NavigationPath;
+}
+
+export interface NavItemProps {
+  item: NavItem;
+  isActive: boolean;
+}

--- a/src/widgets/navigation/ui/bottom-nav.tsx
+++ b/src/widgets/navigation/ui/bottom-nav.tsx
@@ -1,0 +1,39 @@
+import { useLocation } from 'react-router-dom';
+import { NAVIGATION_ITEMS } from '../model/constants';
+import { NavigationItem } from './nav-item';
+import { cn } from 'src/lib/shadcn/lib/utils';
+
+interface BottomNavigationProps {
+  className?: string;
+}
+
+export const BottomNavigation = ({ className }: BottomNavigationProps) => {
+  const { pathname } = useLocation();
+
+  const isActiveRoute = (path: string) => {
+    if (path === '/') {
+      return pathname === '/';
+    }
+    return pathname.startsWith(path);
+  };
+
+  return (
+    <nav 
+      className={cn(
+        "fixed bottom-0 left-0 right-0 z-50",
+        "border-t safe-area-bottom",
+        className
+      )}
+    >
+      <div className="h-16 max-w-md mx-auto flex items-center justify-around">
+        {NAVIGATION_ITEMS.map((item) => (
+          <NavigationItem 
+            key={item.id}
+            item={item}
+            isActive={isActiveRoute(item.path)}
+          />
+        ))}
+      </div>
+    </nav>
+  );
+};

--- a/src/widgets/navigation/ui/nav-item.tsx
+++ b/src/widgets/navigation/ui/nav-item.tsx
@@ -1,0 +1,22 @@
+import { Link } from 'react-router-dom';
+import { cn } from 'src/lib/shadcn/lib/utils';
+import type { NavItemProps } from '../model/types';
+
+export const NavigationItem = ({ item, isActive }: NavItemProps) => {
+  return (
+    <Link
+      to={item.path}
+      className={cn(
+        'flex flex-col items-center justify-center gap-1 w-16 p-1 relative',
+        'transition-colors duration-200',
+        'active:opacity-70',
+        isActive 
+          ? 'text-primary' 
+          : 'text-muted-foreground hover:text-primary'
+      )}
+    >
+      <item.icon className="w-5 h-5" />
+      <span className="text-xs font-medium">{item.label}</span>
+    </Link>
+  );
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,13 @@ export default {
         md: 'calc(var(--radius) - 2px)',
         sm: 'calc(var(--radius) - 4px)',
       },
-      colors: {},
+      colors: {
+        primary: '#000000',
+        muted: {
+          foreground: '#6B7280',
+          background: '#F3F4F6',
+        }
+      },
     },
   },
   plugins: [require('tailwindcss-animate')],


### PR DESCRIPTION
# 하단 네비게이션 라우터 설정 추가

## 변경 사항

- 하단 네비게이션 컴포넌트 및 라우트 설정 추가
- 네비게이션 아이템 아이콘 및 경로 설정

## 테스트 항목

- [ ]  각 네비게이션 아이템 클릭시 정상 라우팅
- [ ]  활성 상태 스타일 정상 적용
- [ ]  모바일 환경에서 터치 인터랙션 확인

## 스크린샷
![image](https://github.com/user-attachments/assets/a56839ea-1984-494f-81e1-4a653dd039ce)
