### PR TITLE
Add API hook 기능 추가와 MSW를 활용한 API 모의 응답 데이터 추가 🚀

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env
+.env.*

--- a/package.json
+++ b/package.json
@@ -59,5 +59,10 @@
     "typescript-eslint": "^8.18.2",
     "vite": "^6.0.5",
     "vitest": "^2.1.8"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,306 @@
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const PACKAGE_VERSION = '2.7.0';
+const INTEGRITY_CHECKSUM = '00729d72e3b82faf54ca8b9621dbb96f';
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse');
+const activeClientIds = new Set();
+
+self.addEventListener('install', function () {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('message', async function (event) {
+  const clientId = event.source.id;
+
+  if (!clientId || !self.clients) {
+    return;
+  }
+
+  const client = await self.clients.get(clientId);
+
+  if (!client) {
+    return;
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  });
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      });
+      break;
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      });
+      break;
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId);
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      });
+      break;
+    }
+
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId);
+      break;
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId);
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId;
+      });
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister();
+      }
+
+      break;
+    }
+  }
+});
+
+self.addEventListener('fetch', function (event) {
+  const { request } = event;
+
+  // Bypass navigation requests.
+  if (request.mode === 'navigate') {
+    return;
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return;
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return;
+  }
+
+  // Generate unique request ID.
+  const requestId = crypto.randomUUID();
+  event.respondWith(handleRequest(event, requestId));
+});
+
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event);
+  const response = await getResponse(event, client, requestId);
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    (async function () {
+      const responseClone = response.clone();
+
+      sendToClient(
+        client,
+        {
+          type: 'RESPONSE',
+          payload: {
+            requestId,
+            isMockedResponse: IS_MOCKED_RESPONSE in response,
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            body: responseClone.body,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+          },
+        },
+        [responseClone.body],
+      );
+    })();
+  }
+
+  return response;
+}
+
+// Resolve the main client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId);
+
+  if (activeClientIds.has(event.clientId)) {
+    return client;
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client;
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  });
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible';
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id);
+    });
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event;
+
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = request.clone();
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers);
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept');
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim());
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      );
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '));
+      } else {
+        headers.delete('accept');
+      }
+    }
+
+    return fetch(requestClone, { headers });
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough();
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough();
+  }
+
+  // Notify the client that a request has been intercepted.
+  const requestBuffer = await request.arrayBuffer();
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        url: request.url,
+        mode: request.mode,
+        method: request.method,
+        headers: Object.fromEntries(request.headers.entries()),
+        cache: request.cache,
+        credentials: request.credentials,
+        destination: request.destination,
+        integrity: request.integrity,
+        redirect: request.redirect,
+        referrer: request.referrer,
+        referrerPolicy: request.referrerPolicy,
+        body: requestBuffer,
+        keepalive: request.keepalive,
+      },
+    },
+    [requestBuffer],
+  );
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data);
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough();
+    }
+  }
+
+  return passthrough();
+}
+
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel();
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error);
+      }
+
+      resolve(event.data);
+    };
+
+    client.postMessage(
+      message,
+      [channel.port2].concat(transferrables.filter(Boolean)),
+    );
+  });
+}
+
+async function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error();
+  }
+
+  const mockedResponse = new Response(response.body, response);
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  });
+
+  return mockedResponse;
+}

--- a/src/app/config.ts
+++ b/src/app/config.ts
@@ -1,1 +1,11 @@
-export const API_BASE_URL = import.meta.env.VITE_API_URL;
+export const config = {
+  env: import.meta.env.VITE_NODE_ENV || 'development',
+  apiUrl: import.meta.env.VITE_API_URL?.replace(/\/$/, '') || '',
+  appTitle: import.meta.env.VITE_APP_TITLE || 'Payment Service',
+  mswEnabled: import.meta.env.VITE_MSW_ENABLED === 'true',
+  isDev: import.meta.env.VITE_NODE_ENV === 'development',
+  isProd: import.meta.env.VITE_NODE_ENV === 'production',
+  isTest: import.meta.env.VITE_NODE_ENV === 'test',
+} as const;
+
+export const API_BASE_URL = config.apiUrl;

--- a/src/app/mocks/handlers.ts
+++ b/src/app/mocks/handlers.ts
@@ -1,5 +1,102 @@
-/**
- * 각각의 handler를 통합하기 위함
- * 예시) export const handlers = [...authHandlers, ...userHandlers];
- */
-export const handlers = [];
+import { API_ENDPOINTS } from '@shared/constants/api-endpoints';
+import { http, HttpResponse } from 'msw';
+
+// user 정보 조회 핸들러 추가
+export const handlers = [
+  http.get(API_ENDPOINTS.USERS.LOGIN, () => {
+    return HttpResponse.json({
+      code: 200,
+      data: {
+        id: 'user-123',
+        firstName: 'John',
+        lastName: 'Doe',
+      },
+    });
+  }),
+
+  // 주문 정보 조회
+  http.get(
+    `/${API_ENDPOINTS.PAYMENT.ORDER.INFO(':orderToken')}`,
+    ({ params }) => {
+      const { orderToken } = params;
+      return HttpResponse.json({
+        code: 200,
+        data: {
+          orderToken: `order-${orderToken}`,
+          orderId: `order-${orderToken}`,
+          orderName: '테스트 상품 외2',
+          amount: 15000,
+          store: '테스트 가맹점',
+          url: 'https://example.com',
+        },
+      });
+    },
+  ),
+
+  // 결제 요청
+  http.post(`/${API_ENDPOINTS.PAYMENT.PROCESS(':orderId')}`, () => {
+    return HttpResponse.json({
+      code: 200,
+    });
+  }),
+
+  // 결제 취소
+  http.post(`/${API_ENDPOINTS.PAYMENT.CANCEL(':orderId')}`, () => {
+    return HttpResponse.json({
+      code: 200,
+    });
+  }),
+
+  // 결제 내역 목록 조회
+  http.get(`/${API_ENDPOINTS.MANAGEMENT.HISTORY.LIST}`, () => {
+    return HttpResponse.json({
+      code: 200,
+      data: {
+        items: [
+          {
+            historyId: 'history-001',
+            orderId: 'order-001',
+            orderName: '테스트 상품 A외 2건',
+            paymentStatus: 'COMPLETED', // COMPLETED, CANCELED
+            paymentMethod: 'CARD',
+            amount: 15000,
+            createdAt: '2024-03-20T09:00:00',
+          },
+          {
+            historyId: 'history-002',
+            orderId: 'order-002',
+            orderName: '테스트 상품 B',
+            paymentStatus: 'CANCELED',
+            paymentMethod: 'CARD',
+            amount: 25000,
+            createdAt: '2024-03-19T15:30:00',
+          },
+        ],
+        totalCount: 2,
+      },
+    });
+  }),
+
+  // 결제 내역 상세 조회
+  http.get(`/${API_ENDPOINTS.MANAGEMENT.HISTORY.DETAIL(':historyId')}`, () => {
+    return HttpResponse.json({
+      code: 200,
+      data: {
+        historyId: 'history-001',
+        orderId: 'order-001',
+        orderName: '테스트 상품 A외 2건',
+        paymentStatus: 'COMPLETED',
+        paymentMethod: 'CARD',
+        amount: 15000,
+        cardInfo: {
+          cardCompany: '신한카드',
+          cardNumber: '123456******7890',
+          installmentPeriod: 0,
+        },
+        store: '테스트 가맹점',
+        createdAt: '2024-03-20T09:00:00',
+        canceledAt: null,
+      },
+    });
+  }),
+];

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -7,6 +7,7 @@ import { withSuspense } from './providers/with-suspense';
 import { ROUTES } from '@shared/config/routes';
 import { SplashPage } from '@pages/basic/splash';
 import ModalUITest from '@pages/test/ModalUITest';
+import ApiHookTest from '@pages/test/ApiHookTest';
 
 // Lazy load pages
 const LoginPage = lazy(() =>
@@ -58,6 +59,10 @@ const routes = {
     {
       path: '/modal-test',
       element: <ModalUITest />,
+    },
+    {
+      path: '/api-hook-test',
+      element: <ApiHookTest />,
     },
   ],
 };

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_NODE_ENV: 'development' | 'production' | 'test';
+  readonly VITE_API_URL: string;
+  readonly VITE_MSW_ENABLED: string;
+  readonly VITE_APP_TITLE: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/pages/test/ApiHookTest.tsx
+++ b/src/pages/test/ApiHookTest.tsx
@@ -1,0 +1,103 @@
+import {
+  useOrderInfo,
+  useRequestPayment,
+  useCancelPayment,
+  useHistoryList,
+  useHistoryDetail,
+} from '@shared/hooks/queries/usePayments';
+
+const ApiHookTest = () => {
+  // 1. 주문 정보 조회 테스트
+  const { data: orderData, isLoading: orderLoading } =
+    useOrderInfo('test-order-123');
+
+  // 2. 결제 요청/취소 테스트
+  const { mutate: requestPayment, isPending: requestPending } =
+    useRequestPayment();
+  const { mutate: cancelPayment, isPending: cancelPending } =
+    useCancelPayment();
+
+  // 3. 결제 내역 조회 테스트
+  const { data: historyList } = useHistoryList();
+  const { data: historyDetail } = useHistoryDetail('history-123');
+
+  // 결제 요청 핸들러
+  const handlePaymentRequest = () => {
+    requestPayment('test-order-123', {
+      onSuccess: () => {
+        alert('결제가 성공적으로 처리되었습니다.');
+      },
+      onError: (error) => {
+        alert(`결제 처리 중 오류가 발생했습니다: ${error.message}`);
+      },
+    });
+  };
+
+  // 결제 취소 핸들러
+  const handlePaymentCancel = () => {
+    cancelPayment('test-order-123', {
+      onSuccess: () => {
+        alert('결제가 성공적으로 취소되었습니다.');
+      },
+      onError: (error) => {
+        alert(`결제 취소 중 오류가 발생했습니다: ${error.message}`);
+      },
+    });
+  };
+
+  if (orderLoading) return <div>주문 정보 로딩 중...</div>;
+
+  return (
+    <div className='p-4 space-y-8'>
+      <section>
+        <h2 className='text-xl font-bold mb-4'>🔍 주문 정보 테스트</h2>
+        <div className='bg-gray-50 p-4 rounded-lg'>
+          <p>주문 ID: {orderData?.orderId}</p>
+          <p>상품명: {orderData?.orderName}</p>
+          <p>금액: {orderData?.amount}원</p>
+          <p>가맹점: {orderData?.store}</p>
+        </div>
+      </section>
+
+      <section>
+        <h2 className='text-xl font-bold mb-4'>💳 결제 요청/취소 테스트</h2>
+        <div className='space-x-4'>
+          <button
+            onClick={handlePaymentRequest}
+            disabled={requestPending}
+            className='bg-blue-500 text-white px-4 py-2 rounded'
+          >
+            {requestPending ? '처리 중...' : '결제 요청'}
+          </button>
+          <button
+            onClick={handlePaymentCancel}
+            disabled={cancelPending}
+            className='bg-red-500 text-white px-4 py-2 rounded'
+          >
+            {cancelPending ? '처리 중...' : '결제 취소'}
+          </button>
+        </div>
+      </section>
+
+      <section>
+        <h2 className='text-xl font-bold mb-4'>📋 결제 내역 테스트</h2>
+        <div className='space-y-4'>
+          <div>
+            <h3 className='font-bold mb-2'>결제 내역 목록</h3>
+            <pre className='bg-gray-50 p-4 rounded-lg'>
+              {JSON.stringify(historyList, null, 2)}
+            </pre>
+          </div>
+          <div>
+            <h3 className='font-bold mb-2'>결제 상세 내역</h3>
+            <pre className='bg-gray-50 p-4 rounded-lg'>
+              {JSON.stringify(historyDetail, null, 2)}
+            </pre>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default ApiHookTest;

--- a/src/shared/api/api.ts
+++ b/src/shared/api/api.ts
@@ -16,6 +16,7 @@ const httpClient = ky.create({
   headers: {
     'Content-Type': 'application/json',
   },
+  credentials: 'include',
   hooks: {
     /**
      * 요청 전 헤더에 인증 토큰을 추가합니다.

--- a/src/shared/api/services/auth.ts
+++ b/src/shared/api/services/auth.ts
@@ -1,0 +1,11 @@
+import { api } from '../api';
+import { API_ENDPOINTS } from '@shared/constants/api-endpoints';
+import type { LoginDTO, RegisterDTO } from '../types';
+
+export const authService = {
+  login: (data: LoginDTO) => api.post(API_ENDPOINTS.USERS.LOGIN, data),
+
+  register: (data: RegisterDTO) => api.post(API_ENDPOINTS.USERS.REGISTER, data),
+
+  logout: () => api.post(API_ENDPOINTS.USERS.LOGOUT, {}),
+};

--- a/src/shared/api/services/payment.ts
+++ b/src/shared/api/services/payment.ts
@@ -1,0 +1,22 @@
+import { api } from '../api';
+import { API_ENDPOINTS } from '@shared/constants/api-endpoints';
+import type { HistoryDetailDTO, HistoryDTO, OrderInfoDTO } from '../types';
+
+export const paymentService = {
+  getOrderInfo: (orderToken: string) =>
+    api.get<OrderInfoDTO>(API_ENDPOINTS.PAYMENT.ORDER.INFO(orderToken)),
+
+  requestPayment: (orderId: string) =>
+    api.post(API_ENDPOINTS.PAYMENT.PROCESS(orderId), {}),
+
+  cancelPayment: (orderId: string) =>
+    api.post(API_ENDPOINTS.PAYMENT.CANCEL(orderId), {}),
+
+  getHistoryList: () =>
+    api.get<HistoryDTO[]>(API_ENDPOINTS.MANAGEMENT.HISTORY.LIST),
+
+  getHistoryDetail: (historyId: string) =>
+    api.get<HistoryDetailDTO>(
+      API_ENDPOINTS.MANAGEMENT.HISTORY.DETAIL(historyId),
+    ),
+};

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -1,0 +1,33 @@
+export type RegisterDTO = {
+  email: string;
+  password: string;
+  name: string;
+};
+
+export type LoginDTO = {
+  email: string;
+  password: string;
+};
+
+// TODO: 응답 데이터 논의 필요
+export type OrderInfoDTO = {
+  orderId: string;
+  orderName: string;
+  amount: number;
+  store: string;
+  url?: string;
+};
+
+// TODO: 응답 데이터 논의 필요
+export type HistoryDTO = {
+  id: number;
+  orderId: string;
+  amount: number;
+};
+
+// TODO: 응답 데이터 논의 필요
+export type HistoryDetailDTO = {
+  id: number;
+  orderId: string;
+  amount: number;
+};

--- a/src/shared/constants/api-endpoints.ts
+++ b/src/shared/constants/api-endpoints.ts
@@ -1,0 +1,31 @@
+export const API_ENDPOINTS = {
+  USERS: {
+    LOGIN: 'api/v1/users/login', // 로그인
+    REGISTER: 'api/v1/users', // 회원가입
+    LOGOUT: 'api/v1/users/logout', // 로그아웃
+    REFRESH: 'api/v1/users/refresh', // 토큰 재발급 ( 논의 필요 )
+  },
+  PAYMENT: {
+    ORDER: {
+      INFO: (orderToken: string) => `api/v1/payments/${orderToken}/info`, // 주문 상세 정보 조회
+    },
+    PROCESS: (orderId: string) => `api/v1/payments/${orderId}/process`, // QR 결제 요청
+    CANCEL: (orderId: string) => `api/v1/payments/${orderId}/cancel`, // QR 결제 취소
+  },
+  MANAGEMENT: {
+    HISTORY: {
+      LIST: 'api/v1/managements/histories', // 결제 내역 목록 조회
+      DETAIL: (historyId: string) =>
+        `api/v1/managements/histories/${historyId}`, // 결제 내역 상세 조회
+    },
+  },
+} as const;
+
+export const QUERY_KEY = {
+  PAYMENT: {
+    ORDER_INFO: 'payment/order-info',
+  },
+  MANAGEMENT: {
+    HISTORY: 'management/history',
+  },
+} as const;

--- a/src/shared/hooks/queries/useAuth.ts
+++ b/src/shared/hooks/queries/useAuth.ts
@@ -1,0 +1,21 @@
+import { authService } from '@shared/api/services/auth';
+import type { LoginDTO, RegisterDTO } from '@shared/api/types';
+import { useMutation } from '@tanstack/react-query';
+
+export const useLogin = () => {
+  return useMutation({
+    mutationFn: (data: LoginDTO) => authService.login(data),
+  });
+};
+
+export const useRegister = () => {
+  return useMutation({
+    mutationFn: (data: RegisterDTO) => authService.register(data),
+  });
+};
+
+export const useLogout = () => {
+  return useMutation({
+    mutationFn: () => authService.logout(),
+  });
+};

--- a/src/shared/hooks/queries/usePayments.ts
+++ b/src/shared/hooks/queries/usePayments.ts
@@ -1,0 +1,39 @@
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { paymentService } from '@shared/api/services/payment';
+import { QUERY_KEY } from '@shared/constants/api-endpoints';
+
+export const useOrderInfo = (orderToken: string) => {
+  return useQuery({
+    queryKey: [QUERY_KEY.PAYMENT.ORDER_INFO, orderToken],
+    queryFn: () => paymentService.getOrderInfo(orderToken),
+    select: (response) => response.data,
+  });
+};
+
+export const useRequestPayment = () => {
+  return useMutation({
+    mutationFn: (orderId: string) => paymentService.requestPayment(orderId),
+  });
+};
+
+export const useCancelPayment = () => {
+  return useMutation({
+    mutationFn: (orderId: string) => paymentService.cancelPayment(orderId),
+  });
+};
+
+export const useHistoryList = () => {
+  return useQuery({
+    queryKey: [QUERY_KEY.MANAGEMENT.HISTORY],
+    queryFn: () => paymentService.getHistoryList(),
+    select: (response) => response.data,
+  });
+};
+
+export const useHistoryDetail = (id: string) => {
+  return useQuery({
+    queryKey: [QUERY_KEY.MANAGEMENT.HISTORY, id],
+    queryFn: () => paymentService.getHistoryDetail(id),
+    select: (response) => response.data,
+  });
+};


### PR DESCRIPTION
## 작업 내용
- 결제 시스템 관련 API Hook 추가
- MSW(Mock Service Worker)를 활용한 API 모의 응답 데이터 구현
- API Hook 테스트를 위한 전용 페이지 `/api-hook-test` 구현
- 환경변수 설정 파일 추가

## 테스트 가능 API 목록
### 사용자 관련
- `POST api/v1/users/login` - 로그인
- `POST api/v1/users` - 회원가입
- `POST api/v1/users/logout` - 로그아웃

### 결제 관련
- `GET api/v1/payments/:orderToken/info` - 주문 상세 정보 조회 ( BE - API 요청 해야함 )
- `POST api/v1/payments/:orderId/process` - QR 결제 요청
- `POST api/v1/payments/:orderId/cancel` - QR 결제 취소

### 결제 관리
- `GET api/v1/managements/histories` - 결제 내역 목록 조회
- `GET api/v1/managements/histories/:historyId` - 결제 내역 상세 조회

## API Hook 테스트 방법
1. 노션 - [FE] 문서 > env 파일정보 에서 env 파일을 루트 폴더로 붙어넣기 
2. `/api-hook-test` 페이지 접속
3. 개발자도구 > console 에서 [MSW] Mocking enabled. 메시지가 출력되는지 확인
4. 페이지에서 확인 가능한 기능:
   - 주문 정보 조회 테스트
   - 결제 요청/취소 테스트
   - 결제 내역 목록 및 상세 조회 테스트

### 테스트 시나리오
1. **주문 정보 조회**
   - 페이지 진입 시 자동으로 주문 정보가 로딩됨
   - 로딩 상태 및 데이터 표시 확인

2. **결제 요청/취소**
   - "결제 요청" 버튼 클릭 → 결제 처리 테스트
   - "결제 취소" 버튼 클릭 → 취소 처리 테스트
   - 각 액션 시 성공/실패 알림 확인

3. **결제 내역**
   - 목록 및 상세 데이터 자동 로딩
   - JSON 형식으로 데이터 확인 가능

## 스크린샷
![localhost_5173_api-hook-test](https://github.com/user-attachments/assets/c3d68a25-0c65-4eb9-ad5e-633ff8193268) 
