### PR TITLE
refactor: 공통 레이아웃 수정

### DIFF
--- a/src/app/layouts/bottom-nav-layout.tsx
+++ b/src/app/layouts/bottom-nav-layout.tsx
@@ -1,10 +1,20 @@
 import { Outlet } from 'react-router-dom';
 import { BottomNavigation } from '@widgets/navigation';
+import { cn } from '@shared/ui/shadcn/lib/utils';
+import { theme } from '@shared/styles/theme';
 
 export const BottomNavLayout = () => {
   return (
-    <div className='min-h-screen'>
-      <main className='container'>
+    <div className='h-[100dvh]'>
+      <header
+        className={cn(
+          `sticky bg-white  flex items-center top-0 h-14 w-responsive_container mx-auto border-b`,
+          theme.safe_area_inline_padding,
+        )}
+      >
+        Header
+      </header>
+      <main className={cn('w-responsive_container mx-auto pb-[4rem] bg-white')}>
         <Outlet />
       </main>
       <BottomNavigation />

--- a/src/app/layouts/default-layout.tsx
+++ b/src/app/layouts/default-layout.tsx
@@ -1,9 +1,10 @@
+import { cn } from '@shared/ui/shadcn/lib/utils';
 import { Outlet } from 'react-router-dom';
 
 export const DefaultLayout = () => {
   return (
-    <div className='min-h-screen'>
-      <main className='container mx-auto px-4 py-8'>
+    <div className='h-[100dvh]'>
+      <main className={cn('w-responsive_container mx-auto bg-white')}>
         <Outlet />
       </main>
     </div>

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -7,6 +7,7 @@ import { ROUTES } from '@shared/config/routes';
 import SplashPage from '@pages/splash';
 import ModalUITest from '@pages/test/ModalUITest';
 import ApiHookTest from '@pages/test/ApiHookTest';
+import ButtonSample from '@pages/test/ButtonSample';
 
 // Lazy load pages
 const LoginPage = lazy(() =>
@@ -83,6 +84,10 @@ const routes = {
     {
       path: '/modal-test',
       element: <ModalUITest />,
+    },
+    {
+      path: '/button-test',
+      element: <ButtonSample />,
     },
     {
       path: '/api-hook-test',

--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,10 @@
 }
 
 @layer base {
+  body {
+    min-width: 375px;
+    background-color: #f3f3f3;
+  }
   body:has([data-enable-background-scroll='true']) {
     overflow: auto;
   }

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -1,4 +1,5 @@
 import Button from '@shared/ui/button/Button';
+import PageLayout from '@shared/ui/PageLayout';
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
@@ -18,7 +19,7 @@ export const LoginPage = () => {
   };
 
   return (
-    <div className='h-screen flex flex-col items-center justify-center -m-8'>
+    <PageLayout className='flex flex-col items-center justify-center'>
       <img src='/logo.png' className='w-24' alt='Logo' />
 
       <form className='w-[356px] flex flex-col' onSubmit={onSubmit}>
@@ -67,7 +68,7 @@ export const LoginPage = () => {
           로그인
         </Button>
       </form>
-    </div>
+    </PageLayout>
   );
 };
 

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -1,10 +1,11 @@
+import Button from '@shared/ui/button/Button';
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 export const LoginPage = () => {
   const [isShow, setIsShow] = useState<boolean>(false);
-  const [email, setEmail] = useState<string | undefined>();
-  const [password, setPassword] = useState<string | undefined>();
+  const [email, setEmail] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
   const navigate = useNavigate();
 
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -57,12 +58,14 @@ export const LoginPage = () => {
 
         <div role='separator' className='pt-4' />
 
-        <button
-          type='submit'
-          className='h-12 bg-[#18A0FB] border-none rounded-full text-white font-bold'
+        <Button
+          size={'extraLarge'}
+          disabled={email.length === 0 || password.length === 0}
+          isPending={false}
+          rounded
         >
           로그인
-        </button>
+        </Button>
       </form>
     </div>
   );

--- a/src/pages/payment/detail.tsx
+++ b/src/pages/payment/detail.tsx
@@ -1,4 +1,5 @@
-import { CircleCheck, CircleX } from 'lucide-react';
+import Icon from '@shared/ui/icon/Icon';
+import PageLayout from '@shared/ui/PageLayout';
 import { useMemo } from 'react';
 
 type PaymentStatus = 'success' | 'canceled';
@@ -8,13 +9,13 @@ export const PaymentDetailPage = () => {
   const status = useMemo<PaymentStatus>(() => 'canceled', []);
 
   return (
-    <div className='w-full h-[calc(100vh-64px)] px-4 flex flex-col justify-center'>
+    <PageLayout hasNav className='flex flex-col justify-center'>
       {/* status Icon */}
       <div className='w-24 h-24 bg-gray-200 rounded-full flex items-center justify-center mx-auto'>
         {status === 'success' ? (
-          <CircleCheck size={48} color='#23A26D' />
+          <Icon name='CircleCheck' size={48} color='#23A26D' />
         ) : (
-          <CircleX size={48} color='#f00' />
+          <Icon name='CircleCheck' size={48} color='#f00' />
         )}
       </div>
 
@@ -79,7 +80,7 @@ export const PaymentDetailPage = () => {
           {Number(5000).toLocaleString('ko')} KRW
         </p>
       </div>
-    </div>
+    </PageLayout>
   );
 };
 

--- a/src/pages/payment/main.tsx
+++ b/src/pages/payment/main.tsx
@@ -1,14 +1,9 @@
-import { CircleUserRound } from 'lucide-react';
 import PaymentList from './components/PaymentList';
+import PageLayout from '@shared/ui/PageLayout';
 
 const PaymentPage = () => {
   return (
-    <div className='p-4 pb-24'>
-      <div className='w-full h-12'>
-        <div className='h-full flex justify-end items-center mr-2 cursor-pointer'>
-          <CircleUserRound size={24} color='#6B7280' />
-        </div>
-      </div>
+    <PageLayout hasNav className='pt-6 pb-24'>
       <ul>
         {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((item) => (
           <PaymentList key={item} />
@@ -18,7 +13,7 @@ const PaymentPage = () => {
       <button className='w-full h-12 bg-white text-[#18A0FB] border border-[#18A0FB] rounded-full font-bold'>
         더보기
       </button>
-    </div>
+    </PageLayout>
   );
 };
 

--- a/src/pages/qr/main.tsx
+++ b/src/pages/qr/main.tsx
@@ -1,14 +1,17 @@
+import PageLayout from '@shared/ui/PageLayout';
+
 const QRPage = () => {
   return (
-    <div
-      className='bg-gradient-to-br from-[#3c1488] via-[#408693] to-[#1e7f84] w-full h-screen flex justify-center items-center'
+    <PageLayout
+      hasNav
+      className='bg-gradient-to-br from-[#3c1488] via-[#408693] to-[#1e7f84] h-full flex justify-center items-center px-0'
       style={{
-        background:
+        backgroundImage:
           'linear-gradient(161deg, rgba(60,20,136,1) 0%, rgba(64,134,147,1) 79%, rgba(30,127,132,1) 100%)',
       }}
     >
-      <div className='w-72 h-72 bg-white opacity-50'></div>
-    </div>
+      <div className='w-[50%] aspect-square bg-white opacity-50'></div>
+    </PageLayout>
   );
 };
 

--- a/src/pages/qr/payment/detail.tsx
+++ b/src/pages/qr/payment/detail.tsx
@@ -1,12 +1,8 @@
+import PageLayout from '@shared/ui/PageLayout';
+
 const QRPaymentDetailPage = () => {
   return (
-    <div
-      className='bg-gradient-to-br from-[#3c1488] via-[#408693] to-[#1e7f84] w-full h-screen flex justify-center items-center'
-      style={{
-        margin: '-32px -16px',
-        width: 'calc(100% + 32px)',
-      }}
-    >
+    <PageLayout className='bg-gradient-to-br from-[#3c1488] via-[#408693] to-[#1e7f84] w-full  flex justify-center items-center'>
       <div className='bg-white w-[320px] h-[600px] rounded-[1rem] flex flex-col justify-center items-center'>
         <img src='/logo.png' className='w-24' alt='Logo' />
         <p className='mt-8 text-2xl font-medium'>결제를 하시겠습니까?</p>
@@ -59,7 +55,7 @@ const QRPaymentDetailPage = () => {
           취소하기
         </button>
       </div>
-    </div>
+    </PageLayout>
   );
 };
 

--- a/src/pages/test/ButtonSample.tsx
+++ b/src/pages/test/ButtonSample.tsx
@@ -1,0 +1,548 @@
+import Button from '@shared/ui/button/Button';
+
+const ButtonSample = () => {
+  return (
+    <div className='p-10 w-full flex flex-col gap-10 overflow-x-auto'>
+      <div className='flex flex-col gap-3'>
+        <h3 className='text-[1.4rem] font-medium'>Default</h3>
+        <div className='flex gap-3'>
+          <Button width={'fit'} leftIcon='Camera' rightIcon='List'>
+            Button
+          </Button>
+          <Button width={'fit'} rounded>
+            Button
+          </Button>
+          <Button width={'fit'} isPending>
+            Button
+          </Button>
+          <Button width={'fit'} disabled onClick={() => alert('click')}>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='small'>
+            Button
+          </Button>
+          <Button width={'fit'} size='small' rounded>
+            Button
+          </Button>
+          <Button width={'fit'} size='small' isPending>
+            Button
+          </Button>
+          <Button width={'fit'} size='small' disabled>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='medium'>
+            Button
+          </Button>
+          <Button width={'fit'} size='medium' rounded>
+            Button
+          </Button>
+          <Button width={'fit'} size='medium' isPending>
+            Button
+          </Button>
+          <Button width={'fit'} size='medium' disabled>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='large'>
+            Button
+          </Button>
+          <Button width={'fit'} size='large' rounded>
+            Button
+          </Button>
+          <Button width={'fit'} size='large' isPending>
+            Button
+          </Button>
+          <Button width={'fit'} size='large' disabled>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='extraLarge'>
+            Button
+          </Button>
+          <Button width={'fit'} size='extraLarge' rounded>
+            Button
+          </Button>
+          <Button width={'fit'} size='extraLarge' isPending>
+            Button
+          </Button>
+          <Button width={'fit'} size='extraLarge' disabled>
+            Button
+          </Button>
+        </div>
+      </div>
+
+      <div className='flex flex-col gap-3'>
+        <h3 className='text-[1.4rem] font-medium'>Secondary</h3>
+        <div className='flex gap-3'>
+          <Button width={'fit'} variant='secondary'>
+            Button
+          </Button>
+          <Button width={'fit'} variant='secondary' rounded>
+            Button
+          </Button>
+          <Button width={'fit'} variant='secondary' isPending>
+            Button
+          </Button>
+          <Button width={'fit'} variant='secondary' disabled>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='small' variant='secondary'>
+            Button
+          </Button>
+          <Button width={'fit'} size='small' variant='secondary' rounded>
+            Button
+          </Button>
+          <Button width={'fit'} size='small' variant='secondary' isPending>
+            Button
+          </Button>
+          <Button width={'fit'} size='small' variant='secondary' disabled>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='medium' variant='secondary'>
+            Button
+          </Button>
+          <Button width={'fit'} size='medium' variant='secondary' rounded>
+            Button
+          </Button>
+          <Button width={'fit'} size='medium' variant='secondary' isPending>
+            Button
+          </Button>
+          <Button width={'fit'} size='medium' variant='secondary' disabled>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='large' variant='secondary'>
+            Button
+          </Button>
+          <Button width={'fit'} size='large' variant='secondary' rounded>
+            Button
+          </Button>
+          <Button width={'fit'} size='large' variant='secondary' isPending>
+            Button
+          </Button>
+          <Button width={'fit'} size='large' variant='secondary' disabled>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='extraLarge' variant='secondary'>
+            Button
+          </Button>
+          <Button width={'fit'} size='extraLarge' variant='secondary' rounded>
+            Button
+          </Button>
+          <Button width={'fit'} size='extraLarge' variant='secondary' isPending>
+            Button
+          </Button>
+          <Button width={'fit'} size='extraLarge' variant='secondary' disabled>
+            Button
+          </Button>
+        </div>
+      </div>
+
+      <div className='flex flex-col gap-3'>
+        <h3 className='text-[1.4rem] font-medium'>Destructive</h3>
+        <div className='flex gap-3'>
+          <Button width={'fit'} variant='destructive'>
+            Button
+          </Button>
+          <Button width={'fit'} variant='destructive' rounded>
+            Button
+          </Button>
+          <Button width={'fit'} variant='destructive' isPending>
+            Button
+          </Button>
+          <Button width={'fit'} variant='destructive' disabled>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='small' variant='destructive'>
+            Button
+          </Button>
+          <Button width={'fit'} size='small' variant='destructive' rounded>
+            Button
+          </Button>
+          <Button width={'fit'} size='small' variant='destructive' isPending>
+            Button
+          </Button>
+          <Button width={'fit'} size='small' variant='destructive' disabled>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='medium' variant='destructive'>
+            Button
+          </Button>
+          <Button width={'fit'} size='medium' variant='destructive' rounded>
+            Button
+          </Button>
+          <Button width={'fit'} size='medium' variant='destructive' isPending>
+            Button
+          </Button>
+          <Button width={'fit'} size='medium' variant='destructive' disabled>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='large' variant='destructive'>
+            Button
+          </Button>
+          <Button width={'fit'} size='large' variant='destructive' rounded>
+            Button
+          </Button>
+          <Button width={'fit'} size='large' variant='destructive' isPending>
+            Button
+          </Button>
+          <Button width={'fit'} size='large' variant='destructive' disabled>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='extraLarge' variant='destructive'>
+            Button
+          </Button>
+          <Button width={'fit'} size='extraLarge' variant='destructive' rounded>
+            Button
+          </Button>
+          <Button
+            width={'fit'}
+            size='extraLarge'
+            variant='destructive'
+            isPending
+          >
+            Button
+          </Button>
+          <Button
+            width={'fit'}
+            size='extraLarge'
+            variant='destructive'
+            disabled
+          >
+            Button
+          </Button>
+        </div>
+      </div>
+
+      <div className='flex flex-col gap-3'>
+        <h3 className='text-[1.4rem] font-medium'>Outline_default</h3>
+        <div className='flex gap-3'>
+          <Button width={'fit'} variant='outline_default'>
+            Button
+          </Button>
+          <Button width={'fit'} variant='outline_default' rounded>
+            Button
+          </Button>
+          <Button width={'fit'} variant='outline_default' isPending>
+            Button
+          </Button>
+          <Button width={'fit'} variant='outline_default' disabled>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='small' variant='outline_default'>
+            Button
+          </Button>
+          <Button width={'fit'} size='small' variant='outline_default' rounded>
+            Button
+          </Button>
+          <Button
+            width={'fit'}
+            size='small'
+            variant='outline_default'
+            isPending
+          >
+            Button
+          </Button>
+          <Button width={'fit'} size='small' variant='outline_default' disabled>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='medium' variant='outline_default'>
+            Button
+          </Button>
+          <Button width={'fit'} size='medium' variant='outline_default' rounded>
+            Button
+          </Button>
+          <Button
+            width={'fit'}
+            size='medium'
+            variant='outline_default'
+            isPending
+          >
+            Button
+          </Button>
+          <Button
+            width={'fit'}
+            size='medium'
+            variant='outline_default'
+            disabled
+          >
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='large' variant='outline_default'>
+            Button
+          </Button>
+          <Button width={'fit'} size='large' variant='outline_default' rounded>
+            Button
+          </Button>
+          <Button
+            width={'fit'}
+            size='large'
+            variant='outline_default'
+            isPending
+          >
+            Button
+          </Button>
+          <Button width={'fit'} size='large' variant='outline_default' disabled>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='extraLarge' variant='outline_default'>
+            Button
+          </Button>
+          <Button
+            width={'fit'}
+            size='extraLarge'
+            variant='outline_default'
+            rounded
+          >
+            Button
+          </Button>
+          <Button
+            width={'fit'}
+            size='extraLarge'
+            variant='outline_default'
+            isPending
+          >
+            Button
+          </Button>
+          <Button
+            width={'fit'}
+            size='extraLarge'
+            variant='outline_default'
+            disabled
+          >
+            Button
+          </Button>
+        </div>
+      </div>
+
+      <div className='flex flex-col gap-3'>
+        <h3 className='text-[1.4rem] font-medium'>Outline_primary</h3>
+        <div className='flex gap-3'>
+          <Button width={'fit'} variant='outline_primary'>
+            Button
+          </Button>
+          <Button width={'fit'} variant='outline_primary' rounded>
+            Button
+          </Button>
+          <Button width={'fit'} variant='outline_primary' isPending>
+            Button
+          </Button>
+          <Button width={'fit'} variant='outline_primary' disabled>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='small' variant='outline_primary'>
+            Button
+          </Button>
+          <Button width={'fit'} size='small' variant='outline_primary' rounded>
+            Button
+          </Button>
+          <Button
+            width={'fit'}
+            size='small'
+            variant='outline_primary'
+            isPending
+          >
+            Button
+          </Button>
+          <Button width={'fit'} size='small' variant='outline_primary' disabled>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='medium' variant='outline_primary'>
+            Button
+          </Button>
+          <Button width={'fit'} size='medium' variant='outline_primary' rounded>
+            Button
+          </Button>
+          <Button
+            width={'fit'}
+            size='medium'
+            variant='outline_primary'
+            isPending
+          >
+            Button
+          </Button>
+          <Button
+            width={'fit'}
+            size='medium'
+            variant='outline_primary'
+            disabled
+          >
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='large' variant='outline_primary'>
+            Button
+          </Button>
+          <Button width={'fit'} size='large' variant='outline_primary' rounded>
+            Button
+          </Button>
+          <Button
+            width={'fit'}
+            size='large'
+            variant='outline_primary'
+            isPending
+          >
+            Button
+          </Button>
+          <Button width={'fit'} size='large' variant='outline_primary' disabled>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='extraLarge' variant='outline_primary'>
+            Button
+          </Button>
+          <Button
+            width={'fit'}
+            size='extraLarge'
+            variant='outline_primary'
+            rounded
+          >
+            Button
+          </Button>
+          <Button
+            width={'fit'}
+            size='extraLarge'
+            variant='outline_primary'
+            isPending
+          >
+            Button
+          </Button>
+          <Button
+            width={'fit'}
+            size='extraLarge'
+            variant='outline_primary'
+            disabled
+          >
+            Button
+          </Button>
+        </div>
+      </div>
+
+      <div className='flex flex-col gap-3'>
+        <h3 className='text-[1.4rem] font-medium'>Outline_ghost</h3>
+        <div className='flex gap-3'>
+          <Button width={'fit'} variant='outline_ghost'>
+            Button
+          </Button>
+          <Button width={'fit'} variant='outline_ghost' rounded>
+            Button
+          </Button>
+          <Button width={'fit'} variant='outline_ghost' isPending>
+            Button
+          </Button>
+          <Button width={'fit'} variant='outline_ghost' disabled>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='small' variant='outline_ghost'>
+            Button
+          </Button>
+          <Button width={'fit'} size='small' variant='outline_ghost' rounded>
+            Button
+          </Button>
+          <Button width={'fit'} size='small' variant='outline_ghost' isPending>
+            Button
+          </Button>
+          <Button width={'fit'} size='small' variant='outline_ghost' disabled>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='medium' variant='outline_ghost'>
+            Button
+          </Button>
+          <Button width={'fit'} size='medium' variant='outline_ghost' rounded>
+            Button
+          </Button>
+          <Button width={'fit'} size='medium' variant='outline_ghost' isPending>
+            Button
+          </Button>
+          <Button width={'fit'} size='medium' variant='outline_ghost' disabled>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='large' variant='outline_ghost'>
+            Button
+          </Button>
+          <Button width={'fit'} size='large' variant='outline_ghost' rounded>
+            Button
+          </Button>
+          <Button width={'fit'} size='large' variant='outline_ghost' isPending>
+            Button
+          </Button>
+          <Button width={'fit'} size='large' variant='outline_ghost' disabled>
+            Button
+          </Button>
+        </div>
+        <div className='flex gap-3'>
+          <Button width={'fit'} size='extraLarge' variant='outline_ghost'>
+            Button
+          </Button>
+          <Button
+            width={'fit'}
+            size='extraLarge'
+            variant='outline_ghost'
+            rounded
+          >
+            Button
+          </Button>
+          <Button
+            width={'fit'}
+            size='extraLarge'
+            variant='outline_ghost'
+            isPending
+          >
+            Button
+          </Button>
+          <Button
+            width={'fit'}
+            size='extraLarge'
+            variant='outline_ghost'
+            disabled
+          >
+            Button
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ButtonSample;

--- a/src/shared/styles/theme.ts
+++ b/src/shared/styles/theme.ts
@@ -1,0 +1,3 @@
+export const theme = {
+  safe_area_inline_padding: 'px-4',
+};

--- a/src/shared/ui/PageLayout.tsx
+++ b/src/shared/ui/PageLayout.tsx
@@ -1,0 +1,23 @@
+import { type ComponentPropsWithoutRef } from 'react';
+import { cn } from '@shared/ui/shadcn/lib/utils';
+import { theme } from '@shared/styles/theme';
+
+interface MainLayoutProps
+  extends Omit<ComponentPropsWithoutRef<'div'>, 'class'> {
+  className?: string;
+  hasNav?: boolean;
+}
+const PageLayout = ({ className, hasNav, ...rest }: MainLayoutProps) => {
+  return (
+    <div
+      className={cn(
+        hasNav ? 'min-h-[calc(100dvh-4rem-3.5rem)]' : 'min-h-[100dvh]',
+        theme.safe_area_inline_padding,
+        className,
+      )}
+      {...rest}
+    />
+  );
+};
+
+export default PageLayout;

--- a/src/shared/ui/Undeveloped.tsx
+++ b/src/shared/ui/Undeveloped.tsx
@@ -1,13 +1,15 @@
+import PageLayout from './PageLayout';
+
 const Undeveloped = () => {
   return (
-    <div className='h-screen flex flex-col items-center justify-center -m-8'>
+    <PageLayout hasNav className='flex flex-col items-center justify-center '>
       <img src='/logo.png' className='w-24' alt='Logo' />
       <h2 className='text-3xl mt-8 mb-8 font-black text-[#18A0FB]'>
         To be continued
       </h2>
 
       <p onClick={() => window.history.back()}>돌아가기</p>
-    </div>
+    </PageLayout>
   );
 };
 

--- a/src/shared/ui/button/Button.tsx
+++ b/src/shared/ui/button/Button.tsx
@@ -1,0 +1,136 @@
+import React, { forwardRef, type ButtonHTMLAttributes } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import Icon, { type IconName } from '@shared/ui/icon/Icon';
+import { cn } from '@shared/ui/shadcn/lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex w-fit gap-[6px] items-center justify-center rounded-[6px] disabled:cursor-not-allowed font-medium',
+  {
+    variants: {
+      variant: {
+        default:
+          'bg-primary text-white hover:bg-gradient-10 disabled:bg-gradient-50 disabled:hover:bg-gradient-50',
+        secondary:
+          'bg-secondary text-white hover:bg-gradient-10 disabled:bg-gradient-50 disabled:hover:bg-gradient-50',
+        destructive:
+          'bg-destructive text-white hover:bg-gradient-10 disabled:bg-gradient-50 disabled:hover:bg-gradient-50',
+        outline_default:
+          'border border-slate-300 bg-white text-slate-800 hover:bg-slate-100 disabled:bg-white disabled:border-slate-200 disabled:text-slate-400',
+        outline_primary:
+          'border border-blue-300 bg-white text-primary hover:bg-blue-50 disabled:bg-white disabled:border-blue-200 disabled:text-blue-400',
+        outline_ghost:
+          'border border-white bg-white text-slate-800 hover:bg-slate-100 hover:border-slate-100 disabled:bg-white disabled:border-white disabled:border-white disabled:text-slate-400',
+      },
+      size: {
+        default: 'h-[2.25rem] px-4 text-[0.875rem]',
+        small: 'h-[1.5rem] px-2 text-[0.75rem]',
+        medium: 'h-[2rem] px-3 text-[0.875rem]',
+        large: 'h-[2.5rem] px-4 text-[1rem]',
+        extraLarge: 'h-[2.75rem] px-5 text-[1.125rem]',
+      },
+      status: {
+        default: null,
+        loading: 'cursor-default',
+      },
+      width: {
+        fit: 'w-fit',
+        full: 'w-full',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+      status: 'default',
+      width: 'full',
+    },
+  },
+);
+
+const iconVariants = cva('', {
+  variants: {
+    variant: {
+      default: 'stroke-white',
+      secondary: 'stroke-white',
+      destructive: 'stroke-white',
+      outline_default: 'stroke-slate-400',
+      outline_primary: 'stroke-blue-400',
+      outline_ghost: 'stroke-slate-400',
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+});
+
+export interface ButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement>,
+    Omit<VariantProps<typeof buttonVariants>, 'status'> {
+  children: React.ReactNode;
+  leftIcon?: IconName;
+  rightIcon?: IconName;
+  isPending?: boolean;
+  rounded?: boolean;
+  className?: string;
+}
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      children,
+      variant,
+      size,
+      disabled,
+      width,
+      isPending = false,
+      leftIcon,
+      rightIcon,
+      rounded,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <button
+        ref={ref} // ref 전달
+        className={`${buttonVariants({
+          variant,
+          size,
+          width,
+          status: isPending ? 'loading' : 'default',
+        })} ${rounded && 'rounded-full'} ${className}`}
+        disabled={isPending || disabled}
+        {...props}
+      >
+        {isPending ? (
+          <Icon
+            className={cn(
+              iconVariants({ variant }),
+              `animate-spin [animation-duration:1600ms]`,
+            )}
+            name='Loader'
+            size='16px'
+          />
+        ) : leftIcon ? (
+          <Icon
+            className={iconVariants({ variant })}
+            name={leftIcon}
+            size='16px'
+          />
+        ) : null}
+        {children}
+        {rightIcon && (
+          <Icon
+            className={iconVariants({ variant })}
+            name={rightIcon}
+            size='16px'
+          />
+        )}
+      </button>
+    );
+  },
+);
+
+Button.displayName = 'Button';
+
+export default Button;

--- a/src/shared/ui/icon/iconPalette.ts
+++ b/src/shared/ui/icon/iconPalette.ts
@@ -1,4 +1,12 @@
-import { List, Camera, CreditCard, LoaderCircle, Loader } from 'lucide-react';
+import {
+  List,
+  Camera,
+  CreditCard,
+  LoaderCircle,
+  Loader,
+  CircleCheck,
+  CircleX,
+} from 'lucide-react';
 
 export const ICON_PALLETTE = {
   List,
@@ -6,4 +14,6 @@ export const ICON_PALLETTE = {
   CreditCard,
   LoaderCircle,
   Loader,
+  CircleCheck,
+  CircleX,
 };

--- a/src/shared/ui/icon/iconPalette.ts
+++ b/src/shared/ui/icon/iconPalette.ts
@@ -1,7 +1,9 @@
-import { List, Camera, CreditCard } from 'lucide-react';
+import { List, Camera, CreditCard, LoaderCircle, Loader } from 'lucide-react';
 
 export const ICON_PALLETTE = {
   List,
   Camera,
   CreditCard,
+  LoaderCircle,
+  Loader,
 };

--- a/src/widgets/navigation/ui/bottom-nav.tsx
+++ b/src/widgets/navigation/ui/bottom-nav.tsx
@@ -2,6 +2,7 @@ import { useLocation } from 'react-router-dom';
 import { NAVIGATION_ITEMS } from '../model/constants';
 import { NavigationItem } from './nav-item';
 import { cn } from '@shared/ui/shadcn/lib/utils';
+import { theme } from '@shared/styles/theme';
 
 interface BottomNavigationProps {
   className?: string;
@@ -20,8 +21,9 @@ export const BottomNavigation = ({ className }: BottomNavigationProps) => {
   return (
     <nav
       className={cn(
-        'fixed bottom-0 left-0 right-0 z-50 bg-white',
+        'fixed min-w-[375px] w-responsive_container bottom-0 left-[50%] translate-x-[-50%] z-50 bg-white',
         'border-t safe-area-bottom',
+        theme.safe_area_inline_padding,
         className,
       )}
     >

--- a/src/widgets/navigation/ui/nav-item.tsx
+++ b/src/widgets/navigation/ui/nav-item.tsx
@@ -13,7 +13,7 @@ export const NavigationItem = ({ item, isActive }: NavItemProps) => {
         'active:opacity-70',
         isActive ? 'text-primary' : 'text-muted-foreground hover:text-primary',
         item.id === 'qr-payment'
-          ? 'text-white bg-[#1293FB] rounded-full w-[72px] h-[72px] absolute -top-5'
+          ? 'text-white bg-[#1293FB] h-na rounded-full w-[72px] h-[72px] absolute bottom-0 translate-y-[calc(-50%+8px)]'
           : '',
       )}
     >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,6 +30,9 @@ export default {
       fontFamily: {
         sans: ['Pretendard', 'Arial', 'sans-serif'],
       },
+      width: {
+        responsive_container: 'min(100%, 600px)',
+      },
     },
   },
   plugins: [require('tailwindcss-animate')],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 /** @type {import('tailwindcss').Config} */
+const colors = require('tailwindcss/colors');
 export default {
   darkMode: ['class'],
   content: ['./index.html', './src/**/*.{ts,tsx,js,jsx}'],
@@ -10,11 +11,21 @@ export default {
         sm: 'calc(var(--radius) - 4px)',
       },
       colors: {
-        primary: '#000000',
+        primary: '#18A0FB',
+        secondary: colors.slate[950],
+        destructive: colors.red[600],
         muted: {
-          foreground: '#6B7280',
+          foreground: colors.gray[400],
           background: '#F3F4F6',
         },
+      },
+      backgroundImage: {
+        'gradient-10':
+          'linear-gradient(0deg, rgba(255,255,255,0.1), rgba(255,255,255,0.1))',
+        'gradient-30':
+          'linear-gradient(0deg, rgba(255,255,255,0.3), rgba(255,255,255,0.3))',
+        'gradient-50':
+          'linear-gradient(0deg, rgba(255,255,255,0.5), rgba(255,255,255,0.5))',
       },
       fontFamily: {
         sans: ['Pretendard', 'Arial', 'sans-serif'],


### PR DESCRIPTION
# Pull Request

## 관련 문서

> Notion 문서, 참고 문서 등을 추가해 주세요.

## 변경 사항

- 기존에 페이지들이 공통된 레이아웃 스타일을 가지지못하고있다.
-`BottomNavLayout`, `DefaultLayout`의 구조를 최대한 공통적으로 가져가고싶어서 레이아웃 스타일을 수정함.
   - css의 min함수를 사용해서 반응형을 구현. 600px까지는 고정되고 그후부터 100%로 반응형이됨
   - body의 min-width를 375px로 설정함 (최근 나오는 모바일 환경의 가장 작은 사이즈)
- PageLayout 컴포넌트를 생성해서 outlet에 렌더되는 페이지들의 스타일을 일괄적으로 관리 할 수 있게함.
   - `hasNav` props로 레이아웃 스타일 변경 가능. `BottomNav를` 사용하는 페이지에서는 해당 props를 true로 사용해주세요

## 테스트 방법

**테스트 1**
`<PageLayout/>`의 `hasNav` Props로 스타일이 변경되는지 확인한다 
**기대값1**
`hasNav`가 true는 BottomNav영역을 확보한다

**테스트 2**
브라우저의 너비를 600px 아래로 줄여본다. 
**기대값 2**
레이아웃이 반응형이된다

## 병합 전 체크리스트

- [ ] [코드 컨벤션](https://www.notion.so/223c52305fc445839e0c5e01bbdb6edc?pvs=4)
- [ ] [커밋 컨벤션](https://www.notion.so/5eead19b22554d2a93b44c0fa6acb470?pvs=4#30ffa838bb3c490ebc5e2de7bcaf7708)
- [ ] [브랜치 컨벤션](https://www.notion.so/5eead19b22554d2a93b44c0fa6acb470?pvs=4#30ffa838bb3c490ebc5e2de7bcaf7708)
- [ ] [에러 케이스](https://www.notion.so/2fd9258cf32944008a4c25c0500d1fc1?pvs=4#b9d7b3f3cc2b49ac8c2c483f41063a54)
