### PR TITLE
refactor: post, put 메소드의 body 리턴이 없을때 케이스 추가

### DIFF
--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -2,7 +2,7 @@ import ky, { HTTPError, type Options } from 'ky';
 import { API_BASE_URL } from '../config';
 
 type ApiResponse<T> = {
-  code: string;
+  code: number;
   data: T;
   message?: string;
 };
@@ -80,11 +80,17 @@ export const api = {
     url: string,
     body: R,
     options?: Options,
-  ): Promise<ApiResponse<T>> => {
+  ): Promise<ApiResponse<T | null>> => {
     try {
-      return await httpClient
-        .post(url, { json: body, ...options })
-        .json<ApiResponse<T>>();
+      const response = await httpClient.put(url, { json: body, ...options });
+      const json = await response.json<ApiResponse<T>>();
+      return response.body
+        ? json
+        : {
+            code: response.status,
+            data: null,
+            message: response.statusText || 'No content returned',
+          };
     } catch (error) {
       return handleError(error);
     }
@@ -103,11 +109,17 @@ export const api = {
     url: string,
     body: R,
     options?: Options,
-  ): Promise<ApiResponse<T>> => {
+  ): Promise<ApiResponse<T | null>> => {
     try {
-      return await httpClient
-        .put(url, { json: body, ...options })
-        .json<ApiResponse<T>>();
+      const response = await httpClient.put(url, { json: body, ...options });
+      const json = await response.json<ApiResponse<T>>();
+      return response.body
+        ? json
+        : {
+            code: response.status,
+            data: null,
+            message: response.statusText || 'No content returned',
+          };
     } catch (error) {
       return handleError(error);
     }


### PR DESCRIPTION
# Pull Request

## 관련 문서

> Notion 문서, 참고 문서 등을 추가해 주세요.

## 변경 사항

> post, put 메소드의 서버에서 body 리턴이 없을때 로직 추가


## 테스트 방법

> 서버에서 post, put 메소드의 body 리턴이 없는 경우 아래의 형태로 body를 return 한다
```
          {
            code: response.status,
            data: null,
            message: response.statusText || 'No content returned',
          };
```


## 병합 전 체크리스트

- [ ] [코드 컨벤션](https://www.notion.so/223c52305fc445839e0c5e01bbdb6edc?pvs=4)
- [ ] [커밋 컨벤션](https://www.notion.so/5eead19b22554d2a93b44c0fa6acb470?pvs=4#30ffa838bb3c490ebc5e2de7bcaf7708)
- [ ] [브랜치 컨벤션](https://www.notion.so/5eead19b22554d2a93b44c0fa6acb470?pvs=4#30ffa838bb3c490ebc5e2de7bcaf7708)
- [ ] [에러 케이스](https://www.notion.so/2fd9258cf32944008a4c25c0500d1fc1?pvs=4#b9d7b3f3cc2b49ac8c2c483f41063a54)
