### PR TITLE
Refactor:useQueryParams 리팩토링

### DIFF
--- a/src/hooks/useLocationState.ts
+++ b/src/hooks/useLocationState.ts
@@ -1,0 +1,73 @@
+import { useLocation } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+
+/**
+ * `location.state` 값을 가져오고 관리하는 커스텀 훅입니다.
+ *
+ * 이 훅은 현재 라우터의 `location.state`를 지정된 타입으로 반환하며,
+ * 상태가 없거나 유효하지 않은 경우 에러를 발생시킵니다.
+ *
+ * @template T - 상태 객체의 타입으로, 키-값 구조(`Record<string, unknown>`)를 가져야 합니다.
+ *
+ * @returns {{
+ *   state: T;
+ *   isLoading: boolean;
+ * }}
+ * - `state`: `location.state` 값을 포함하는 객체로, 제네릭 타입 `T`에 따라 설정됩니다.
+ * - `isLoading`: 상태를 로딩 중인지 나타내는 불리언 값입니다.
+ *
+ * @throws {Error}
+ * - `location.state`가 없거나 객체 타입이 아닌 경우 에러가 발생합니다.
+ * - 상태가 초기화되지 않아 `state`가 `null`일 경우 에러가 발생합니다.
+ *
+ * @example
+ * // location.state의 값이 다음과 같다고 가정합니다:
+ * // { userId: 123, userName: "John Doe" }
+ *
+ * const { state, isLoading } = useLocationState<{
+ *   userId: number;
+ *   userName: string;
+ * }>();
+ *
+ * if (isLoading) {
+ *   return <div>로딩 중...</div>;
+ * }
+ *
+ * return (
+ *   <div>
+ *     <p>사용자 ID: {state.userId}</p>
+ *     <p>사용자 이름: {state.userName}</p>
+ *   </div>
+ * );
+ */
+export const useLocationState = <T extends Record<string, unknown>>(): {
+  state: T;
+  isLoading: boolean;
+} => {
+  const location = useLocation(); // 현재 라우터 위치 가져오기
+  const [state, setState] = useState<T | null>(null); // 상태 초기화 (null로 시작)
+  const [isLoading, setIsLoading] = useState(true); // 로딩 상태 관리
+
+  useEffect(() => {
+    setIsLoading(true); // 로딩 시작
+
+    // `location.state`를 안전하게 T 타입으로 캐스팅
+    const currentState = location.state as T | null;
+
+    // `location.state`가 없거나 객체가 아닐 경우 에러 발생
+    if (!currentState || typeof currentState !== 'object') {
+      throw new Error('라우터 상태가 필요하지만 제공되지 않았습니다.');
+    }
+
+    setState(currentState); // 상태 설정
+    setIsLoading(false); // 로딩 완료
+  }, [location]);
+
+  // 상태가 null인 경우 최종적으로 에러를 발생
+  if (state === null) {
+    throw new Error('location.state가 null입니다');
+  }
+
+  // 상태와 로딩 상태 반환
+  return { state, isLoading };
+};

--- a/src/hooks/useQueryParams.ts
+++ b/src/hooks/useQueryParams.ts
@@ -4,37 +4,31 @@ import { useLocation } from 'react-router-dom';
 /**
  * URL의 쿼리 파라미터를 파싱하고 관리하는 커스텀 훅입니다.
  *
- * 이 훅은 현재 `location.search` 문자열에서 쿼리 파라미터를 추출하여
- * `Record` 객체로 반환합니다. 또한, 쿼리 파라미터를 처리하는 동안의 로딩 상태를
- * 제공합니다.
- *
  * @template T - 쿼리 파라미터 키를 나타내는 문자열 유니온 타입입니다.
- *
- * @param {Record<T, string>} [defaultValue={}] - URL에서 쿼리 파라미터를 찾지 못했을 경우
- * 사용할 기본값입니다. 기본값이 제공되지 않으면 빈 객체를 사용합니다.
  *
  * @returns {{
  *   params: Record<T, string>;
  *   isLoading: boolean;
- * }} `params`는 URL에서 추출한 쿼리 파라미터를 포함하는 객체이며,
+ * }}
+ * `params`는 URL에서 추출한 쿼리 파라미터 객체이며,
  * `isLoading`은 쿼리 파라미터를 처리 중인지 나타내는 로딩 상태입니다.
  *
  * @example
  * // URL: https://example.com?token=abc123&expiredAt=2025-01-01
- * const { params, isLoading } = useQueryParams<'token' | 'expiredAt'>({
- *   token: 'defaultToken',
- *   expiredAt: 'defaultExpiration',
- * });
+ * const { params, isLoading } = useQueryParams<'token' | 'expiredAt'>();
  *
  * console.log(params.token); // "abc123"
  * console.log(params.expiredAt); // "2025-01-01"
  * console.log(isLoading); // false
  */
-export const useQueryParams = <T extends string>(
-  defaultValue: Record<T, string> = {} as Record<T, string>,
-): { params: Record<T, string>; isLoading: boolean } => {
+export const useQueryParams = <T extends string>(): {
+  params: Record<T, string>;
+  isLoading: boolean;
+} => {
   const location = useLocation();
-  const [params, setParams] = useState<Record<T, string>>(defaultValue);
+  const [params, setParams] = useState<Record<T, string>>(
+    {} as Record<T, string>,
+  );
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -50,7 +44,7 @@ export const useQueryParams = <T extends string>(
 
     setParams(result);
     setIsLoading(false);
-  }, [location]);
+  }, [location.search]);
 
   return { params, isLoading };
 };

--- a/src/hooks/useQueryParams.ts
+++ b/src/hooks/useQueryParams.ts
@@ -1,41 +1,54 @@
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
-interface QueryParams {
-  token: string;
-  expiredAt: string;
-  [key: string]: string;
-}
-
-interface UseQueryParamsReturn {
-  params: QueryParams;
-  isLoading: boolean;
-}
-
-export const useQueryParams = (): UseQueryParamsReturn => {
+/**
+ * URL의 쿼리 파라미터를 파싱하고 관리하는 커스텀 훅입니다.
+ *
+ * 이 훅은 현재 `location.search` 문자열에서 쿼리 파라미터를 추출하여
+ * `Record` 객체로 반환합니다. 또한, 쿼리 파라미터를 처리하는 동안의 로딩 상태를
+ * 제공합니다.
+ *
+ * @template T - 쿼리 파라미터 키를 나타내는 문자열 유니온 타입입니다.
+ *
+ * @param {Record<T, string>} [defaultValue={}] - URL에서 쿼리 파라미터를 찾지 못했을 경우
+ * 사용할 기본값입니다. 기본값이 제공되지 않으면 빈 객체를 사용합니다.
+ *
+ * @returns {{
+ *   params: Record<T, string>;
+ *   isLoading: boolean;
+ * }} `params`는 URL에서 추출한 쿼리 파라미터를 포함하는 객체이며,
+ * `isLoading`은 쿼리 파라미터를 처리 중인지 나타내는 로딩 상태입니다.
+ *
+ * @example
+ * // URL: https://example.com?token=abc123&expiredAt=2025-01-01
+ * const { params, isLoading } = useQueryParams<'token' | 'expiredAt'>({
+ *   token: 'defaultToken',
+ *   expiredAt: 'defaultExpiration',
+ * });
+ *
+ * console.log(params.token); // "abc123"
+ * console.log(params.expiredAt); // "2025-01-01"
+ * console.log(isLoading); // false
+ */
+export const useQueryParams = <T extends string>(
+  defaultValue: Record<T, string> = {} as Record<T, string>,
+): { params: Record<T, string>; isLoading: boolean } => {
   const location = useLocation();
+  const [params, setParams] = useState<Record<T, string>>(defaultValue);
   const [isLoading, setIsLoading] = useState(true);
-  const [params, setParams] = useState<QueryParams>({
-    token: '',
-    expiredAt: '',
-  });
 
   useEffect(() => {
-    setIsLoading(true);
-
     const queryParams = new URLSearchParams(location.search);
-    const stateParams = location.state as Partial<QueryParams> | null;
 
-    const tokenValue = queryParams.get('token');
-    const expiredAtValue = queryParams.get('expiredAt');
+    const result = Array.from(queryParams.entries()).reduce(
+      (acc, [key, value]) => {
+        acc[key as T] = value;
+        return acc;
+      },
+      {} as Record<T, string>,
+    );
 
-    setParams((prev) => ({
-      ...prev,
-      token: tokenValue || '',
-      expiredAt: expiredAtValue || '',
-      ...(stateParams || {}),
-    }));
-
+    setParams(result);
     setIsLoading(false);
   }, [location]);
 


### PR DESCRIPTION
# Pull Request

## 관련 문서

> useQueryParams.ts의 jsDOC 주석
> useLocationState.ts의 jsDOC 주석
## 변경 사항

> 기존 useQueryParams는 params뿐 아니라 state의 기능도 포함하고 있어, 두 기능을 분리.
> useQueryParams는 제네릭을 사용하여 쿼리 문자열의 키값들을 Union 타입으로 선언할 수 있도록 수정.
> 분리된 state 기능은 useLocationState라는 새로운 훅으로 재정의하여 상태 관리 역할을 전담. 

## 테스트 방법

1. useQueryParams
  - URL 예: https://example.com?token=abc123&expiredAt=2025-01-01
  - useQueryParams<'token' | 'expiredAt'>()를 호출하여 params 객체를 확인.
```JSX
const { params } = useQueryParams<'token' | 'expiredAt'>();
console.log(params.token); // "abc123"
console.log(params.expiredAt); // "2025-01-01"
```

2. useLocationState
   - 라우터의 location.state에 다음과 같은 값이 있을 경우:
```JSX
{
  userId: 123,
  userName: "John Doe"
}
```
   - useLocationState<{ userId: number; userName: string }>()를 호출하여 state 값을 확인.
```JSX
const { state } = useLocationState<{
  userId: number;
  userName: string;
}>();
console.log(state.userId); // 123
console.log(state.userName); // "John Doe"
```

3. 각 훅에서 잘못된 데이터 또는 초기 값이 없을 때 에러 발생 여부 확인:
 - useQueryParams의 기본값이 제대로 작동하는지 확인.
 - useLocationState 호출 시 location.state가 없을 경우 에러가 발생하는지 확인.


## 병합 전 체크리스트

- [ ] [코드 컨벤션](https://www.notion.so/223c52305fc445839e0c5e01bbdb6edc?pvs=4)
- [ ] [커밋 컨벤션](https://www.notion.so/5eead19b22554d2a93b44c0fa6acb470?pvs=4#30ffa838bb3c490ebc5e2de7bcaf7708)
- [ ] [브랜치 컨벤션](https://www.notion.so/5eead19b22554d2a93b44c0fa6acb470?pvs=4#30ffa838bb3c490ebc5e2de7bcaf7708)
- [ ] [에러 케이스](https://www.notion.so/2fd9258cf32944008a4c25c0500d1fc1?pvs=4#b9d7b3f3cc2b49ac8c2c483f41063a54)
