### PR TITLE
feat: 결제 승인 완료 - sse 통신 임시로 3초 이후 finish 호출 되도록 수정

### DIFF
--- a/src/constants/apiEndpoints.ts
+++ b/src/constants/apiEndpoints.ts
@@ -10,6 +10,7 @@ export const API_ENDPOINTS = {
       INFO: (orderToken: string) => `api/v1/payments/${orderToken}/info`, // 주문 상세 정보 조회
       // 임시
       SSE: 'payment/order/sse',
+      SSE_TEMP: 'payment/order/sse-temp',
     },
     PROCESS: (orderId: string) => `api/v1/payments/${orderId}/process`, // QR 결제 요청
     CANCEL: (orderId: string) => `api/v1/payments/${orderId}/cancel`, // QR 결제 취소

--- a/src/mocks/handlers/order.ts
+++ b/src/mocks/handlers/order.ts
@@ -40,7 +40,31 @@ export const orderHandler = [
     });
 
     return new HttpResponse(stream, {
-      headers: { 'Content-Type': 'text/event-stream' },
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      },
+    });
+  }),
+
+  http.get(API_ENDPOINTS.PAYMENT.ORDER.SSE_TEMP, () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        const message = 'data: {"message": "success"}\n\n';
+        setTimeout(() => {
+          controller.enqueue(encoder.encode(message));
+          controller.close();
+        }, 3000); // 3초 간격으로 메시지 전송
+      },
+    });
+
+    return new HttpResponse(stream, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+      },
     });
   }),
 ];

--- a/src/pages/payment/qr/QRPage.tsx
+++ b/src/pages/payment/qr/QRPage.tsx
@@ -14,7 +14,7 @@ const QRPage = () => {
     // 임시 데이터
     const result_dummy = {
       token: DUMMY_API_CONFIG.ORDER_TOKEN,
-      expiredAt: 171232323232,
+      expiredAt: 1810025200000,
     };
     const state = {
       token: result_dummy.token,

--- a/src/ui/templates/qrCode/QRScanWidget.tsx
+++ b/src/ui/templates/qrCode/QRScanWidget.tsx
@@ -30,11 +30,12 @@ export const QRScanWidget = ({ onScanSuccess }: QRScanWidgetProps) => {
   }, []);
 
   const updateViewportRatio = () => {
+    const MAX_WIDTH = 600;
     const vh = window.innerHeight;
-    const vw = window.innerWidth;
+    const vw = Math.min(window.innerWidth, MAX_WIDTH);
     setViewportRatio({
       width: 100,
-      height: ((vh - 62) / vw) * 100,
+      height: (vh / vw) * 100,
     });
   };
 
@@ -56,9 +57,8 @@ export const QRScanWidget = ({ onScanSuccess }: QRScanWidgetProps) => {
       }
     }
   };
-
   return (
-    <div className='relative h-screen'>
+    <div className='relative h-[calc(100dvh-4rem-3.5rem)]'>
       <div className='absolute inset-0 overflow-hidden'>
         <Scanner
           onScan={onScanSuccess}

--- a/src/ui/templates/qrCode/detail/QRDetailContent.tsx
+++ b/src/ui/templates/qrCode/detail/QRDetailContent.tsx
@@ -1,60 +1,134 @@
+import { API_ENDPOINTS } from '@constants/apiEndpoints';
+import { ROUTES } from '@constants/routes';
+import { useSSE } from '@hooks/useSSE';
 import type { OrderInfoJwtRes } from '@type/responses/payment';
+import Button from '@ui/components/button/Button';
+import LoadingAnimation from '@ui/components/loading/LoadingAnimation';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 interface QRDetailCardProps {
   orderData?: OrderInfoJwtRes;
 }
 const QRDetailContent = ({ orderData }: QRDetailCardProps) => {
+  const navigate = useNavigate();
+
+  const [isPaymentLoading, setPaymentLoading] = useState(false);
+  const [messages, setMessages] = useState<string>('');
+  const { connected, connect, disconnect } = useSSE<{
+    message: string;
+  }>({
+    url: API_ENDPOINTS.PAYMENT.ORDER.SSE_TEMP,
+    onMessage: (data) => {
+      console.log(data);
+      setMessages(data.message);
+    },
+  });
+
+  useEffect(() => {
+    if (messages) {
+      setPaymentLoading(false);
+    }
+  }, [messages]);
+
+  const handlePayment = () => {
+    connect();
+    setPaymentLoading(true);
+  };
+
+  const handleCancel = () => {
+    if (connected) {
+      disconnect();
+    }
+    navigate(ROUTES.PAYMENT.QR);
+  };
+
   return (
     <>
-      <img src='/logo.png' className='w-16' alt='Logo' />
-      <p className=' text-2xl font-medium'>결제를 하시겠습니까?</p>
+      {messages && (
+        <div className='flex flex-col items-center p-6'>
+          <div className='text-lg font-semibold text-gray-800'>
+            결제가 완료되었습니다.
+          </div>
+          <Button
+            onClick={handleCancel}
+            className='mt-4 bg-blue-500 text-white hover:bg-blue-600 transition duration-200'
+          >
+            돌아가기
+          </Button>
+        </div>
+      )}
+      {isPaymentLoading && (
+        <>
+          <LoadingAnimation />
+          <p className=' text-lg font-semibold'>결제가 진행중입니다.</p>
+        </>
+      )}
+      {!isPaymentLoading && !messages && (
+        <>
+          <img src='/logo.png' className='w-16' alt='Logo' />
+          <p className=' text-2xl font-medium'>결제를 하시겠습니까?</p>
 
-      <div role='separator' className='mb-8' />
+          <div role='separator' className='mb-8' />
 
-      <div className='flex justify-between items-center w-full'>
-        <p className='text-gray-500'>상점</p>
-        <p className='overflow-hidden text-ellipsis whitespace-nowrap max-w-[70%]'>
-          {orderData?.merchant_name}
-        </p>
-      </div>
+          <div className='flex justify-between items-center w-full'>
+            <p className='text-gray-500'>상점</p>
+            <p className='overflow-hidden text-ellipsis whitespace-nowrap max-w-[70%]'>
+              {orderData?.merchant_name}
+            </p>
+          </div>
 
-      <div role='separator' className='mb-4' />
+          <div role='separator' className='mb-4' />
 
-      <div className='flex justify-between items-center w-full'>
-        <p className='text-gray-500'>상품</p>
-        <p
-          className='overflow-hidden text-ellipsis whitespace-normal max-w-[70%] line-clamp-2'
-          style={{
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            display: '-webkit-box',
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: 'vertical',
-            whiteSpace: 'normal',
-            maxWidth: '70%',
-          }}
-        >
-          {orderData?.order_name}
-        </p>
-      </div>
+          <div className='flex justify-between items-center w-full'>
+            <p className='text-gray-500'>상품</p>
+            <p
+              className='overflow-hidden text-ellipsis whitespace-normal max-w-[70%] line-clamp-2'
+              style={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+                whiteSpace: 'normal',
+                maxWidth: '70%',
+              }}
+            >
+              {orderData?.order_name}
+            </p>
+          </div>
 
-      <div role='separator' className='mb-4' />
+          <div role='separator' className='mb-4' />
 
-      <div className='flex justify-between items-center w-full'>
-        <p className='text-gray-500'>가격</p>
-        <p className='max-w-[70%] font-bold'>
-          {Number(orderData?.amount).toLocaleString('ko')} KRW
-        </p>
-      </div>
+          <div className='flex justify-between items-center w-full'>
+            <p className='text-gray-500'>가격</p>
+            <p className='max-w-[70%] font-bold'>
+              {Number(orderData?.amount).toLocaleString('ko')} KRW
+            </p>
+          </div>
 
-      <div role='separator' className='mb-8' />
+          <div role='separator' className='mb-8' />
+          <Button
+            variant={'default'}
+            size={'extraLarge'}
+            rounded
+            className='w-[calc(100%-34px)] font-bold'
+            onClick={handlePayment}
+          >
+            결제하기
+          </Button>
 
-      <button className='w-[calc(100%-32px)] h-12 bg-[#18A0FB] text-white font-bold rounded-full'>
-        결제하기
-      </button>
-      <button className='w-[calc(100%-32px)] h-12 text-[#18A0FB] font-bold rounded-full mt-4'>
-        취소하기
-      </button>
+          <Button
+            variant={'outline_primary'}
+            size={'extraLarge'}
+            rounded
+            className='w-[calc(100%-34px)] text-[#18A0FB] font-bold rounded-full mt-4'
+            onClick={handleCancel}
+          >
+            취소하기
+          </Button>
+        </>
+      )}
     </>
   );
 };


### PR DESCRIPTION
# Pull Request

## 관련 문서

> N/A

## 변경 사항

[feat] QR 코드 스캔 위젯 및 결제 승인 완료 페이지 개선

- **QRScanWidget.tsx**
  - 화면 스크롤 생기지 않도록 수정

- **결제 승인 완료 페이지**
  - 결제 완료 후 사용자에게 "결제가 완료되었습니다."라는 메시지를 표시하는 UI 추가
  - "돌아가기" 버튼을 통해 사용자가 이전 페이지로 쉽게 돌아갈 수 있도록 구현
  - 임시로 3초 이후 호출되는 sse 설정

## 테스트 방법

https://github.com/user-attachments/assets/b372aa5f-5956-45e0-b963-fe23d6152890


## 병합 전 체크리스트

- [ ] [코드 컨벤션](https://www.notion.so/223c52305fc445839e0c5e01bbdb6edc?pvs=4)
- [ ] [커밋 컨벤션](https://www.notion.so/5eead19b22554d2a93b44c0fa6acb470?pvs=4#30ffa838bb3c490ebc5e2de7bcaf7708)
- [ ] [브랜치 컨벤션](https://www.notion.so/5eead19b22554d2a93b44c0fa6acb470?pvs=4#30ffa838bb3c490ebc5e2de7bcaf7708)
- [ ] [에러 케이스](https://www.notion.so/2fd9258cf32944008a4c25c0500d1fc1?pvs=4#b9d7b3f3cc2b49ac8c2c483f41063a54)
