### PR TITLE
feat: QR DeepLink용 SuccessUrl 페이지 추가 

### DIFF
--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -6,6 +6,7 @@ export const ROUTES = {
     QR: '/payment/qr',
     DETAIL: '/payment/detail',
     COMPLETE: '/payment/complete',
+    DEEPLINK: '/payment/deeplink/success',
   },
   TRANSACTIONS: {
     LIST: '/transactions',

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -82,7 +82,7 @@ export const api = {
     options?: Options,
   ): Promise<ApiResponse<T | null>> => {
     try {
-      const response = await httpClient.put(url, { json: body, ...options });
+      const response = await httpClient.post(url, { json: body, ...options });
       const json = await response.json<ApiResponse<T>>();
       return response.body
         ? json

--- a/src/pages/payment/detail/QRDeepLinkSuccessPage.tsx
+++ b/src/pages/payment/detail/QRDeepLinkSuccessPage.tsx
@@ -1,25 +1,44 @@
 import { ROUTES } from '@constants/routes';
+import useModal from '@hooks/useModal';
 import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 const QRDeepLinkSuccessPage = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const { openDialog, closeModal } = useModal();
 
   useEffect(() => {
     const token = searchParams.get('token');
     const expiredAt = searchParams.get('expiredAt');
 
-    if (token && expiredAt) {
-      navigate(ROUTES.PAYMENT.DETAIL, {
-        state: { token, expiredAt },
-        replace: true,
-      });
-    } else {
+    if (!token || !expiredAt) {
       navigate(ROUTES.PAYMENT.QR, { replace: true });
+      return;
     }
+
+    const isExpired = Date.now() > new Date(expiredAt).getTime();
+
+    if (isExpired) {
+      console.warn('⚠️ QR 코드 만료됨');
+      openDialog('alert', {
+        title: '오류',
+        description: '만료된 QR 코드입니다.\n다시 시도해 주세요.',
+        confirm: () => {
+          closeModal();
+          navigate(ROUTES.PAYMENT.QR, { replace: true }); // 만료되었을 경우 QR 페이지로 리디렉션
+        },
+      });
+      return;
+    }
+
+    navigate(ROUTES.PAYMENT.DETAIL, {
+      state: { token, expiredAt },
+      replace: true,
+    });
   }, [searchParams, navigate]);
-  return <></>;
+
+  return null;
 };
 
 export default QRDeepLinkSuccessPage;

--- a/src/pages/payment/detail/QRDeepLinkSuccessPage.tsx
+++ b/src/pages/payment/detail/QRDeepLinkSuccessPage.tsx
@@ -1,0 +1,25 @@
+import { ROUTES } from '@constants/routes';
+import { useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+const QRDeepLinkSuccessPage = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  useEffect(() => {
+    const token = searchParams.get('token');
+    const expiredAt = searchParams.get('expiredAt');
+
+    if (token && expiredAt) {
+      navigate(ROUTES.PAYMENT.DETAIL, {
+        state: { token, expiredAt },
+        replace: true,
+      });
+    } else {
+      navigate(ROUTES.PAYMENT.QR, { replace: true });
+    }
+  }, [searchParams, navigate]);
+  return <></>;
+};
+
+export default QRDeepLinkSuccessPage;

--- a/src/pages/payment/detail/QRPaymentDetailPage.tsx
+++ b/src/pages/payment/detail/QRPaymentDetailPage.tsx
@@ -30,7 +30,7 @@ const QRPaymentDetailPage = () => {
     console.log('expiredAt', expiredAt);
     if (!expiredAt) return;
 
-    const isExpired = new Date().getTime() > Number(expiredAt);
+    const isExpired = Date.now() > new Date(expiredAt).getTime();
     if (isExpired && !isOpenDialogRef.current) {
       isOpenDialogRef.current = true;
       openDialog('alert', {

--- a/src/pages/transactions/list/TransactionsListPage.tsx
+++ b/src/pages/transactions/list/TransactionsListPage.tsx
@@ -3,12 +3,8 @@ import PageLayout from '@ui/layouts/PageLayout';
 
 const TransactionsListPage = () => {
   return (
-    <PageLayout hasNav className='pt-6 pb-24'>
+    <PageLayout hasNav>
       <PaymentList />
-
-      <button className='w-full h-12 mt-4 bg-white text-[#18A0FB] border border-[#18A0FB] rounded-full font-bold'>
-        더보기
-      </button>
     </PageLayout>
   );
 };

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -46,6 +46,12 @@ const CardPage = lazy(() =>
   import('@pages/card/list/CardPage').then((m) => ({ default: m.default })),
 );
 
+const QRDeepLinkSuccessPage = lazy(() =>
+  import('@pages/payment/detail/QRDeepLinkSuccessPage').then((m) => ({
+    default: m.default,
+  })),
+);
+
 const SuspendedLoginPage = withSuspense(LoginPage);
 const SuspendedSignupPage = withSuspense(SignupPage);
 
@@ -56,6 +62,7 @@ const SuspendedQRPaymentCompletePage = withSuspense(QRPaymentCompletePage);
 const SuspendedTransactionsPage = withSuspense(TransactionsPage);
 const SuspendedTransactionDetailPage = withSuspense(TransactionDetailPage);
 const SuspendedCardPage = withSuspense(CardPage);
+const SUspendedQRDeepLinkSUccess = withSuspense(QRDeepLinkSuccessPage);
 
 // 라우트 설정
 const routes = {
@@ -75,6 +82,10 @@ const routes = {
         {
           path: ROUTES.PAYMENT.COMPLETE,
           element: <SuspendedQRPaymentCompletePage />,
+        },
+        {
+          path: ROUTES.PAYMENT.DEEPLINK,
+          element: <SUspendedQRDeepLinkSUccess />,
         },
         {
           path: ROUTES.TRANSACTIONS.DETAIL,

--- a/src/ui/components/error/ErrorComponent.tsx
+++ b/src/ui/components/error/ErrorComponent.tsx
@@ -11,7 +11,7 @@ const ErrorComponent = ({ message = '다시 시도해주세요' }) => {
   }, []);
 
   return (
-    <div className='flex flex-col items-center justify-center h-screen'>
+    <div className='flex flex-col items-center justify-center h-full'>
       <p className='text-red-600 text-lg mb-4'>{message}</p>
       <button
         onClick={() => window.location.reload()}

--- a/src/ui/components/loading/LoadingAnimation.tsx
+++ b/src/ui/components/loading/LoadingAnimation.tsx
@@ -1,6 +1,6 @@
 const LoadingAnimation = () => {
   return (
-    <div className='flex items-center justify-center h-screen'>
+    <div className='flex items-center justify-center h-full'>
       <img src='/animate.gif' width={200} />
     </div>
   );

--- a/src/ui/layouts/PageLayout.tsx
+++ b/src/ui/layouts/PageLayout.tsx
@@ -11,7 +11,7 @@ const PageLayout = ({ className, hasNav, ...rest }: MainLayoutProps) => {
   return (
     <div
       className={cn(
-        hasNav ? 'min-h-[calc(100dvh-4rem-3.5rem)]' : 'min-h-[100dvh]',
+        hasNav ? 'min-h-[calc(100dvh-4rem-3.5rem)] grid' : 'min-h-[100dvh]',
         theme.safe_area_inline_padding,
         className,
       )}

--- a/src/ui/templates/qrCode/detail/QRDetailContent.tsx
+++ b/src/ui/templates/qrCode/detail/QRDetailContent.tsx
@@ -66,7 +66,7 @@ const QRDetailContent = ({ orderData }: QRDetailCardProps) => {
       )}
       {!isPaymentLoading && !messages && (
         <>
-          <img src='/logo.png' className='w-16' alt='Logo' />
+          <img src='/logo.png' className='w-14 mb-8' alt='Logo' />
           <p className=' text-2xl font-medium'>결제를 하시겠습니까?</p>
 
           <div role='separator' className='mb-8' />

--- a/src/ui/templates/transactions/PaymentList.tsx
+++ b/src/ui/templates/transactions/PaymentList.tsx
@@ -18,7 +18,7 @@ const PaymentList = () => {
   }
 
   return (
-    <ul>
+    <ul className='pt-6 pb-24'>
       {data.transactions?.map((list) => (
         <li
           key={list.id}


### PR DESCRIPTION
# Pull Request

## 관련 문서

> Notion 문서, 참고 문서 등을 추가해 주세요.

## 변경 사항

모바일에서 DeepLink를 받아줄 페이지 추가 <QRDeepLinkSuccessPage /> , /payment/deeplink/success
- 데스크탑과는 다르게 모바일에서는 QR을 딥링크용으로 사용하기 때문에 SDK에서 던져주는 token, expiredAt값을 받아서 location.state로 넣어줄 페이지가 필요했음


## 테스트 방법

1. 주소창에 BASE_URL/payment/deeplink/success?token=HWgwrj5nn0WFyFGtSoANf0LAt30goF6TNqGjrVeVEsc=&expiredAt=2025-02-07T06:02:37.294Z 로 이동 

2. 결제 상세창으로 이동되고 결제내역이 뜸



## 병합 전 체크리스트

- [ ] [코드 컨벤션](https://www.notion.so/223c52305fc445839e0c5e01bbdb6edc?pvs=4)
- [ ] [커밋 컨벤션](https://www.notion.so/5eead19b22554d2a93b44c0fa6acb470?pvs=4#30ffa838bb3c490ebc5e2de7bcaf7708)
- [ ] [브랜치 컨벤션](https://www.notion.so/5eead19b22554d2a93b44c0fa6acb470?pvs=4#30ffa838bb3c490ebc5e2de7bcaf7708)
- [ ] [에러 케이스](https://www.notion.so/2fd9258cf32944008a4c25c0500d1fc1?pvs=4#b9d7b3f3cc2b49ac8c2c483f41063a54)
