### PR TITLE
refactor: 결제내역 리스트 및 상세 스타일 변경

### DIFF
--- a/src/ui/templates/modal/PaymentHistoryDetailModal.tsx
+++ b/src/ui/templates/modal/PaymentHistoryDetailModal.tsx
@@ -26,12 +26,11 @@ const PaymentHistoryDetailModal = ({
           {data.map((trx) => (
             <li
               key={trx.id}
-              className=' p-4 border-b last:border-0 border-gray-100 flex flex-col gap-2'
+              className='py-4 border-b last:border-0 border-gray-100 flex flex-col gap-2'
             >
               <div className='flex justify-between items-center'>
-                <p className='text-sm text-gray-700'>
-                  금액:{' '}
-                  <span className='font-semibold text-blue-600'>
+                <p className='text-lg text-gray-700'>
+                  <span className='font-semibold'>
                     {trx.amount.toLocaleString()} 원
                   </span>
                 </p>

--- a/src/ui/templates/transactions/PaymentList.tsx
+++ b/src/ui/templates/transactions/PaymentList.tsx
@@ -89,7 +89,7 @@ const PaymentList = () => {
                 </div>
                 <div></div>
                 <Button
-                  variant={'secondary'}
+                  variant={'outline_primary'}
                   onClick={() =>
                     openModal(
                       <PaymentHistoryDetailModal


### PR DESCRIPTION
# Pull Request

## 관련 문서

> Notion 문서, 참고 문서 등을 추가해 주세요.

## 변경 사항

1. 결제내역 리스트 상세내역 보기 버튼 톤앤매너에 맞는 스타일로 수정
2. 결제내역 상세에서 패딩 조절

## 테스트 방법

> 변경 사항에 대해 최대한 상세하게 테스트 가이드를 작성해 주세요.
> 문제를 재현하고, 해당 변경 사항을 테스트할 수 있게 단계별로 자세히 작성해 주세요.
> UI 변경 사항의 경우 `Before` / `After` 스크린샷 혹은 `GIF`를 첨부해도 좋아요.

## 병합 전 체크리스트

- [x] [코드 컨벤션](https://www.notion.so/223c52305fc445839e0c5e01bbdb6edc?pvs=4)
- [x] [커밋 컨벤션](https://www.notion.so/5eead19b22554d2a93b44c0fa6acb470?pvs=4#30ffa838bb3c490ebc5e2de7bcaf7708)
- [x] [브랜치 컨벤션](https://www.notion.so/5eead19b22554d2a93b44c0fa6acb470?pvs=4#30ffa838bb3c490ebc5e2de7bcaf7708)
- [ ] [에러 케이스](https://www.notion.so/2fd9258cf32944008a4c25c0500d1fc1?pvs=4#b9d7b3f3cc2b49ac8c2c483f41063a54)
