### PR TITLE
feat: 결제내역 리스트 더보기 페이지네이션 + useInfiniteQuery기능 추가 , 공통 레이아웃 스타일 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,10 +7,10 @@ import { useAuthStore } from '@stores/auth';
 import { useEffect } from 'react';
 
 // MSW를 개발 환경에서만 시작하도록 설정합니다.
-if (process.env.NODE_ENV === 'development') {
-  const { worker } = await import('@mocks/browser');
-  worker.start();
-}
+// if (process.env.NODE_ENV === 'development') {
+//   const { worker } = await import('@mocks/browser');
+//   worker.start();
+// }
 
 const queryClient = new QueryClient();
 function App() {

--- a/src/api/services/payment.ts
+++ b/src/api/services/payment.ts
@@ -28,7 +28,7 @@ export const paymentService = {
     status,
     page,
     limit,
-  }: TransactionListFilter) => {
+  }: Required<TransactionListFilter>) => {
     return api.get<{ payments: TransactionsRes[] }>(
       API_ENDPOINTS.MANAGEMENT.HISTORY.LIST,
       {

--- a/src/constants/payment.ts
+++ b/src/constants/payment.ts
@@ -7,7 +7,6 @@
 export const TRANSACTION_STATUS = {
   APPROVED: 'APPROVED',
   CANCELLED: 'CANCELLED',
-  REFUNDED: 'REFUNDED',
 } as const;
 
 /**

--- a/src/hooks/queries/usePayments.ts
+++ b/src/hooks/queries/usePayments.ts
@@ -1,5 +1,5 @@
 import { paymentService } from '@api/services/payment';
-import { useQuery, useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import { QUERY_KEY } from '@constants/apiEndpoints';
 import type { TransactionStatus } from '@type/payment';
 
@@ -35,39 +35,32 @@ export type TransactionListFilter = {
   limit: number;
 };
 
-export const useTransactionList = ({
-  startDate,
-  endDate,
-  status,
-  page,
-  limit,
-}: TransactionListFilter) => {
-  return useSuspenseQuery({
-    queryKey: [
-      QUERY_KEY.MANAGEMENT.HISTORY,
-      startDate,
-      endDate,
-      status,
-      page,
-      limit,
-    ],
-    queryFn: () =>
-      paymentService.getTransactionList({
-        startDate,
-        endDate,
-        status,
-        page,
-        limit,
-      }),
-    select: (response) => {
-      if (response.ok) {
-        return response.data.payments;
-      }
-      throw new Error(response.error.message);
-    },
-    // placeholderData: (previousData) => previousData ?? undefined,
-  });
-};
+// export const useTransactionList = ({
+//   startDate,
+//   endDate,
+//   status,
+//   page,
+//   limit,
+// }: TransactionListFilter) => {
+//   return useSuspenseQuery({
+//     queryKey: [QUERY_KEY.MANAGEMENT.HISTORY, startDate, endDate, page, limit],
+//     queryFn: () =>
+//       paymentService.getTransactionList({
+//         startDate,
+//         endDate,
+//         status,
+//         page,
+//         limit,
+//       }),
+//     select: (response) => {
+//       if (response.ok) {
+//         return response.data.payments;
+//       }
+//       throw new Error(response.error.message);
+//     },
+//     // placeholderData: (previousData) => previousData ?? undefined,
+//   });
+// };
 
 export const useTransactionDetail = (id: string) => {
   return useQuery({

--- a/src/hooks/queries/usePayments.ts
+++ b/src/hooks/queries/usePayments.ts
@@ -28,9 +28,9 @@ export const useCancelPayment = () => {
 };
 
 export type TransactionListFilter = {
-  startDate: string;
-  endDate: string;
-  status: TransactionStatus | 'null';
+  startDate?: string;
+  endDate?: string;
+  status?: TransactionStatus | 'null';
   page: number;
   limit: number;
 };

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,12 @@
   padding-bottom: env(safe-area-inset-bottom);
 }
 
+html,
+body,
+#root {
+  height: 100%;
+}
+
 @layer base {
   body {
     min-width: 375px;

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -10,8 +10,8 @@ export const LoginPage = () => {
 
   const [isShow, setIsShow] = useState<boolean>(false);
   const [loginData, setLoginData] = useState<LoginReq>({
-    email: 'test@test.com',
-    password: 'password123',
+    email: 'pay200tester@pay.com',
+    password: 'qwer1234',
   });
 
   const onChangeValue = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/ui/components/withSuspense/WithSuspense.tsx
+++ b/src/ui/components/withSuspense/WithSuspense.tsx
@@ -1,5 +1,4 @@
-import { Suspense } from 'react';
-import type { ComponentType } from 'react';
+import { Suspense, type ComponentType } from 'react';
 import { LoadingSpinner } from '@ui/components/loading/LoadingSpinner';
 
 interface WithSuspenseOptions {

--- a/src/ui/layouts/bottomNavLayout.tsx
+++ b/src/ui/layouts/bottomNavLayout.tsx
@@ -9,7 +9,7 @@ import { ROUTES } from '@constants/routes';
 export const BottomNavLayout = () => {
   const { logout } = useAuth();
   return (
-    <div className='grid h-full grid-rows-[3.5rem_auto_4rem] '>
+    <div className='grid h-full grid-rows-[3.5rem_auto_4rem]'>
       <header
         className={cn(
           `grid-rows-1 sticky bg-white justify-between flex items-center top-0 h-14 w-responsive_container mx-auto border-b`,
@@ -23,7 +23,9 @@ export const BottomNavLayout = () => {
           <Icon name='LogOut' size={20} />
         </button>
       </header>
-      <main className={cn('w-responsive_container mx-auto bg-white ')}>
+      <main
+        className={cn('w-responsive_container mx-auto bg-white overflow-auto')}
+      >
         <Outlet />
       </main>
       <BottomNavigation />

--- a/src/ui/layouts/bottomNavLayout.tsx
+++ b/src/ui/layouts/bottomNavLayout.tsx
@@ -9,10 +9,10 @@ import { ROUTES } from '@constants/routes';
 export const BottomNavLayout = () => {
   const { logout } = useAuth();
   return (
-    <div className='h-[100dvh]'>
+    <div className='grid h-full grid-rows-[3.5rem_auto_4rem] '>
       <header
         className={cn(
-          `sticky bg-white justify-between flex items-center top-0 h-14 w-responsive_container mx-auto border-b`,
+          `grid-rows-1 sticky bg-white justify-between flex items-center top-0 h-14 w-responsive_container mx-auto border-b`,
           theme.safe_area_inline_padding,
         )}
       >
@@ -23,7 +23,7 @@ export const BottomNavLayout = () => {
           <Icon name='LogOut' size={20} />
         </button>
       </header>
-      <main className={cn('w-responsive_container mx-auto pb-[4rem] bg-white')}>
+      <main className={cn('w-responsive_container mx-auto bg-white ')}>
         <Outlet />
       </main>
       <BottomNavigation />

--- a/src/ui/layouts/defaultLayout.tsx
+++ b/src/ui/layouts/defaultLayout.tsx
@@ -3,7 +3,7 @@ import { Outlet } from 'react-router-dom';
 
 export const DefaultLayout = () => {
   return (
-    <div className='h-[100dvh]'>
+    <div className='grid grid h-full grid-rows-auto  h-full'>
       <main className={cn('w-responsive_container mx-auto bg-white')}>
         <Outlet />
       </main>

--- a/src/ui/layouts/defaultLayout.tsx
+++ b/src/ui/layouts/defaultLayout.tsx
@@ -3,7 +3,7 @@ import { Outlet } from 'react-router-dom';
 
 export const DefaultLayout = () => {
   return (
-    <div className='grid grid h-full grid-rows-auto  h-full'>
+    <div className='grid  grid-rows-auto  h-full'>
       <main className={cn('w-responsive_container mx-auto bg-white')}>
         <Outlet />
       </main>

--- a/src/ui/templates/navigation/bottomNav.tsx
+++ b/src/ui/templates/navigation/bottomNav.tsx
@@ -21,13 +21,13 @@ export const BottomNavigation = ({ className }: BottomNavigationProps) => {
   return (
     <nav
       className={cn(
-        'fixed min-w-[375px] w-responsive_container bottom-0 left-[50%] translate-x-[-50%] z-50 bg-white',
+        'h-16 min-w-[375px] mx-auto w-responsive_container  bg-white',
         'border-t safe-area-bottom',
         theme.safe_area_inline_padding,
         className,
       )}
     >
-      <div className='h-16 max-w-md mx-auto flex items-center justify-around'>
+      <div className='h-full max-w-md mx-auto flex items-center justify-around'>
         {NAVIGATION_ITEMS.map((item) => (
           <NavigationItem
             key={item.id}

--- a/src/ui/templates/transactions/PaymentList.tsx
+++ b/src/ui/templates/transactions/PaymentList.tsx
@@ -1,13 +1,20 @@
-import { useTransactionList } from '@hooks/queries/usePayments';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { api } from '@lib/apiClient';
+import type { TransactionsRes } from '@type/responses/payment';
+import { API_ENDPOINTS, QUERY_KEY } from '@constants/apiEndpoints';
 import useModal from '@hooks/useModal';
 import Button from '@ui/components/button/Button';
 import ErrorComponent from '@ui/components/error/ErrorComponent';
 import LoadingAnimation from '@ui/components/loading/LoadingAnimation';
 import PaymentHistoryDetailModal from '../modal/PaymentHistoryDetailModal';
+
 /**
- * 상태별 스타일 지정
+ * @todo 리스트 가상화 하기
  */
-export const getStatusClass = (status: string) => {
+/**
+ * 결제 상태별 스타일 클래스 반환 함수
+ */
+export const getStatusClass = (status: string): string => {
   switch (status) {
     case 'APPROVED':
       return 'bg-green-100 text-green-700';
@@ -19,16 +26,54 @@ export const getStatusClass = (status: string) => {
       return 'bg-gray-100 text-gray-700';
   }
 };
+
+/**
+ * API 응답 타입
+ */
+type PaymentHistoryResponse = {
+  payments: TransactionsRes[];
+};
+
+const LIMIT_COUNT = 3;
+
+/**
+ * 결제 내역 리스트 컴포넌트
+ */
 const PaymentList = () => {
-  const { data, isLoading, isError } = useTransactionList({
-    startDate: '2025-01-01',
-    endDate: '2025-12-31',
-    status: 'null',
-    page: 0,
-    limit: 999,
-  });
+  const today = new Date();
+  const formattedUTCDate = today.toISOString().split('T')[0]; // UTC 날짜 변환
   const { openModal } = useModal();
-  if (isLoading) {
+
+  const { data, isFetchingNextPage, isError, fetchNextPage, hasNextPage } =
+    useInfiniteQuery({
+      queryKey: [QUERY_KEY.MANAGEMENT.HISTORY],
+      queryFn: async ({ pageParam = 0 }: { pageParam: number }) => {
+        const response = await api.get<PaymentHistoryResponse>(
+          API_ENDPOINTS.MANAGEMENT.HISTORY.LIST,
+          {
+            searchParams: {
+              startDate: '2024-01-01',
+              endDate: formattedUTCDate,
+              page: pageParam.toString(),
+              limit: LIMIT_COUNT.toString(),
+            },
+          },
+        );
+
+        if (response.ok) {
+          return response.data;
+        }
+        return { payments: [] };
+      },
+      initialPageParam: 0, // ✅ 필수: 첫 번째 요청의 기본 pageParam 값 설정
+      getNextPageParam: (lastPage, allPages) => {
+        return lastPage.payments.length < LIMIT_COUNT
+          ? undefined
+          : allPages.length;
+      },
+    });
+
+  if (!data) {
     return (
       <div className='w-full mx-auto pt-12 pb-24 space-y-12'>
         <LoadingAnimation />
@@ -39,40 +84,45 @@ const PaymentList = () => {
   if (isError) {
     return <ErrorComponent />;
   }
+
+  // 전체 결제 내역 리스트
+  const allPayments = data.pages.flatMap((page) => page.payments);
+
   return (
     <div className='w-full mx-auto pt-12 pb-24 space-y-12'>
       <h1 className='text-2xl font-bold text-gray-900 text-center'>
         결제 내역
       </h1>
 
-      {data?.length === 0 ? (
+      {allPayments.length === 0 ? (
         <p className='text-gray-500'>결제 내역이 없습니다.</p>
       ) : (
         <ul className='flex flex-col gap-4'>
-          {data?.map((paymentItem) => {
-            const hasTransaction = paymentItem.transactions.length > 0; //임시
-            const latestTransaction = paymentItem.transactions[0];
+          {allPayments.map((paymentItem) => {
+            const hasTransaction = paymentItem.transactions.length > 0;
+            const latestTransaction = hasTransaction
+              ? paymentItem.transactions[0]
+              : null;
+
             return (
               <li
                 key={paymentItem.paymentKey}
                 className='bg-white rounded-xl border px-6 py-4 border-gray-200'
-                onClick={() => {}}
               >
-                {/* 결제 정보 */}
                 <header className='flex justify-between gap-4 items-center pb-2'>
-                  {hasTransaction && (
+                  {latestTransaction && (
                     <span
-                      className={`px-3 py-1 rounded-full text-xs font-medium ${getStatusClass(latestTransaction.status)}`}
+                      className={`px-3 py-1 rounded-full text-xs font-medium ${getStatusClass(
+                        latestTransaction.status,
+                      )}`}
                     >
                       {latestTransaction.status}
                     </span>
                   )}
                   <p className='text-xs text-gray-400'>
                     결제일:{' '}
-                    {hasTransaction &&
-                      new Date(
-                        latestTransaction.completedAt,
-                      ).toLocaleString()}{' '}
+                    {latestTransaction &&
+                      new Date(latestTransaction.completedAt).toLocaleString()}
                   </p>
                 </header>
                 <div className='flex flex-col gap-1 pb-4'>
@@ -81,7 +131,7 @@ const PaymentList = () => {
                   </h2>
                   <div className='flex justify-between items-center'>
                     <p className='text-2xl font-semibold'>
-                      {hasTransaction &&
+                      {latestTransaction &&
                         latestTransaction.amount.toLocaleString()}
                       원
                     </p>
@@ -91,9 +141,8 @@ const PaymentList = () => {
                     </p>
                   </div>
                 </div>
-                <div></div>
                 <Button
-                  variant={'outline_primary'}
+                  variant='outline_primary'
                   onClick={() =>
                     openModal(
                       <PaymentHistoryDetailModal
@@ -107,6 +156,17 @@ const PaymentList = () => {
               </li>
             );
           })}
+          {hasNextPage && (
+            <li>
+              <Button
+                onClick={() => fetchNextPage()}
+                isPending={isFetchingNextPage}
+                size={'extraLarge'}
+              >
+                더 보기
+              </Button>
+            </li>
+          )}
         </ul>
       )}
     </div>

--- a/src/ui/templates/transactions/PaymentList.tsx
+++ b/src/ui/templates/transactions/PaymentList.tsx
@@ -29,7 +29,11 @@ const PaymentList = () => {
   });
   const { openModal } = useModal();
   if (isLoading) {
-    return <LoadingAnimation />;
+    return (
+      <div className='w-full mx-auto pt-12 pb-24 space-y-12'>
+        <LoadingAnimation />
+      </div>
+    );
   }
 
   if (isError) {


### PR DESCRIPTION
# Pull Request

## 관련 문서

> Notion 문서, 참고 문서 등을 추가해 주세요.

## 변경 사항

1. 결제내역 리스트 페이지네이션 추가 
  - useInfiniteQuery로 페이지네이션 구성
2. 공통 레이아웃 스타일 수정

## 테스트 방법

1. 결제내역에서 더보기 리스트를 누른다 
2. 그러면 리스트를 추가로 호출 
3. 추가 데이터가 없으면 더보기 버튼 렌더 X 

## 병합 전 체크리스트

- [x] [코드 컨벤션](https://www.notion.so/223c52305fc445839e0c5e01bbdb6edc?pvs=4)
- [x] [커밋 컨벤션](https://www.notion.so/5eead19b22554d2a93b44c0fa6acb470?pvs=4#30ffa838bb3c490ebc5e2de7bcaf7708)
- [x] [브랜치 컨벤션](https://www.notion.so/5eead19b22554d2a93b44c0fa6acb470?pvs=4#30ffa838bb3c490ebc5e2de7bcaf7708)
- [ ] [에러 케이스](https://www.notion.so/2fd9258cf32944008a4c25c0500d1fc1?pvs=4#b9d7b3f3cc2b49ac8c2c483f41063a54)
